### PR TITLE
[projectfirma/#1121] Show PM charts on Org pages

### DIFF
--- a/Source/ProjectFirma.Web/Models/Organization.cs
+++ b/Source/ProjectFirma.Web/Models/Organization.cs
@@ -132,7 +132,7 @@ namespace ProjectFirma.Web.Models
         public PerformanceMeasureChartViewData GetPerformanceMeasureChartViewData(PerformanceMeasure performanceMeasure)
         {
             var projectIDs = ProjectOrganizations.Select(x => x.ProjectID).ToList();
-            return new PerformanceMeasureChartViewData(performanceMeasure, true, ChartViewMode.Large, projectIDs);
+            return new PerformanceMeasureChartViewData(performanceMeasure, true, ChartViewMode.Small, projectIDs);
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
@@ -41,14 +41,23 @@ Source code is available upon request via <support@sitkatech.com>.
     <script src="@Url.Content("~/Content/leaflet/leaflet.legend/leaflet-legend.js")" type="text/javascript"></script>
     <link href="@Url.Content("~/Content/leaflet/leaflet.legend/leaflet-legend.css")" rel="stylesheet" type="text/css"/>
     <script type="text/javascript">
+        // Overrode initial drawChartsOnLoadCallback to not draw the chart, we want to wait until they click a tab
+        window.GoogleCharts.drawChartsOnLoadCallback = function (chartJsons) {
+            // ReSharper disable once MissingHasOwnPropertyInForeach
+            for (var chartName in chartJsons)
+            {
+                var modifiedJson = chartJsons[chartName];
+                this.chartWrappers[chartName] = new google.visualization.ChartWrapper(modifiedJson);
+                // this.chartWrappers[chartName].draw(); // don't draw this thing here, wait until the tab is clicked
+            }
+        };
         jQuery(function() {
             var runOnceResults = false,
                 runOnceFundingAndProjects = false;
             jQuery("#resultsTab").on("shown.bs.tab", function() {
                 if (!runOnceResults) {
-                    _.forOwn(GoogleCharts.chartWrappers,
+                    _.forOwn(window.GoogleCharts.chartWrappers,
                         function(chartWrapper) {
-                            chartWrapper.getChart().clearChart();
                             chartWrapper.draw();
                         });
                 }
@@ -307,7 +316,7 @@ Source code is available upon request via <support@sitkatech.com>.
                         <div class="row">
                             @foreach (var performanceMeasureChartViewData in batch)
                             {
-                                <div class="col-xs-12 col-sm-6">
+                                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6">
                                     <div class="panel panelFirma">
                                         <div class="panel-body">
                                             <div style="width: 500px; margin: auto;">


### PR DESCRIPTION
Wait to draw PM charts until results tab has been clicked

https://projects.sitkatech.com/projects/projectfirma/cards/1121

+ Make charts switch from two to one column at medium screenwidth
+ Wait to draw chart until tab has been clicked to fix dumb display errors once and for all