### PR TITLE
Features/1227 project type selector

### DIFF
--- a/Database/LookupTables/dbo.FirmaPageType.sql
+++ b/Database/LookupTables/dbo.FirmaPageType.sql
@@ -37,4 +37,4 @@ values
 (44, 'MonitoringProgramsList', 'Monitoring Programs', 1),
 (45, 'ProposeProjectInstructions', 'Propose Project Instructions', 2),
 (46, 'ProjectStewardOrganizationList', 'ProjectStewardOrganizationList', 1),
-(47, 'ImportHistoricProjectInstructions', 'Import Historic Project Instructions', 2)
+(47, 'EnterHistoricProjectInstructions', 'Enter Historic Project Instructions', 2)

--- a/Database/LookupTables/dbo.FirmaPageType.sql
+++ b/Database/LookupTables/dbo.FirmaPageType.sql
@@ -36,4 +36,5 @@ values
 (43, 'ClassificationsList', 'Classifications List', 1),
 (44, 'MonitoringProgramsList', 'Monitoring Programs', 1),
 (45, 'ProposeProjectInstructions', 'Propose Project Instructions', 2),
-(46, 'ProjectStewardOrganizationList', 'ProjectStewardOrganizationList', 1)
+(46, 'ProjectStewardOrganizationList', 'ProjectStewardOrganizationList', 1),
+(47, 'ImportHistoricProjectInstructions', 'Import Historic Project Instructions', 2)

--- a/Database/ReleaseScript/121 - Add new values to the FirmaPage table for the newly created EnterHistoricProjectInstructions page type..sql
+++ b/Database/ReleaseScript/121 - Add new values to the FirmaPage table for the newly created EnterHistoricProjectInstructions page type..sql
@@ -1,0 +1,10 @@
+INSERT INTO dbo.FirmaPageType
+values (47, 'EnterHistoricProjectInstructions', 'Enter Historic Project Instructions', 2)
+
+INSERT INTO dbo.FirmaPage
+(TenantID, FirmaPageTypeID, FirmaPageContent)
+SELECT 
+	TenantID as TenantID,
+	47 as FirmaPageTypeID,
+	NULL as FirmaPageContent
+from dbo.Tenant 

--- a/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
@@ -67,11 +67,11 @@ namespace ProjectFirma.Web.Controllers
             {
                 return RazorPartialView<ProjectTypeSelection, ProjectTypeSelectionViewData, ProjectTypeSelectionViewModel>(viewData, viewModel);
             }
-            return new ModalDialogFormJsonResult(SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(null)));
+            return new ModalDialogFormJsonResult(SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null)));
         }
 
         [LoggedInAndNotUnassignedRoleUnclassifiedFeature]
-        public ActionResult Instructions(int? projectID)
+        public ActionResult InstructionsProposal(int? projectID)
         {
             var firmaPageType = FirmaPageType.ToType(FirmaPageTypeEnum.ProposeProjectInstructions);
             var firmaPage = FirmaPage.GetFirmaPageByPageType(firmaPageType);
@@ -81,14 +81,14 @@ namespace ProjectFirma.Web.Controllers
                 var project = HttpRequestStorage.DatabaseEntities.Projects.GetProject(projectID.Value);
 
                 var proposalSectionsStatus = new ProposalSectionsStatus(project);
-                var viewData = new InstructionsViewData(CurrentPerson, project, proposalSectionsStatus, firmaPage, false);
+                var viewData = new InstructionsProposalViewData(CurrentPerson, project, proposalSectionsStatus, firmaPage, false);
 
-                return RazorView<Instructions, InstructionsViewData>(viewData);
+                return RazorView<InstructionsProposal, InstructionsProposalViewData>(viewData);
             }
             else
             {
-                var viewData = new InstructionsViewData(CurrentPerson, firmaPage, true);
-                return RazorView<Instructions, InstructionsViewData>(viewData);
+                var viewData = new InstructionsProposalViewData(CurrentPerson, firmaPage, true);
+                return RazorView<InstructionsProposal, InstructionsProposalViewData>(viewData);
             }
         }
 
@@ -300,7 +300,7 @@ namespace ProjectFirma.Web.Controllers
             var project = projectPrimaryKey.EntityObject;
             if (project == null)
             {
-                return RedirectToAction(new SitkaRoute<ProjectCreateController>(x => x.Instructions(project.ProjectID)));
+                return RedirectToAction(new SitkaRoute<ProjectCreateController>(x => x.InstructionsProposal(project.ProjectID)));
             }
             var performanceMeasureActualSimples =
                 project.PerformanceMeasureActuals.OrderBy(pam => pam.PerformanceMeasureID)
@@ -329,7 +329,7 @@ namespace ProjectFirma.Web.Controllers
             var project = projectPrimaryKey.EntityObject;
             if (project == null)
             {
-                return RedirectToAction(new SitkaRoute<ProjectCreateController>(x => x.Instructions(project.ProjectID)));
+                return RedirectToAction(new SitkaRoute<ProjectCreateController>(x => x.InstructionsProposal(project.ProjectID)));
             }
             if (!ModelState.IsValid)
             {
@@ -428,7 +428,7 @@ namespace ProjectFirma.Web.Controllers
             
             if (project == null)
             {
-                return RedirectToAction(new SitkaRoute<ProjectCreateController>(x => x.Instructions(projectPrimaryKey.PrimaryKeyValue)));
+                return RedirectToAction(new SitkaRoute<ProjectCreateController>(x => x.InstructionsProposal(projectPrimaryKey.PrimaryKeyValue)));
             }
             var projectFundingSourceExpenditures = project.ProjectFundingSourceExpenditures.ToList();
             var calendarYearRange = projectFundingSourceExpenditures.CalculateCalendarYearRangeForExpenditures(project);
@@ -446,7 +446,7 @@ namespace ProjectFirma.Web.Controllers
             
             if (project == null)
             {
-                return RedirectToAction(new SitkaRoute<ProjectCreateController>(x => x.Instructions(projectPrimaryKey.PrimaryKeyValue)));
+                return RedirectToAction(new SitkaRoute<ProjectCreateController>(x => x.InstructionsProposal(projectPrimaryKey.PrimaryKeyValue)));
             }
 
             viewModel.ProjectID = project.ProjectID;

--- a/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
@@ -67,7 +67,12 @@ namespace ProjectFirma.Web.Controllers
             {
                 return RazorPartialView<ProjectTypeSelection, ProjectTypeSelectionViewData, ProjectTypeSelectionViewModel>(viewData, viewModel);
             }
-            return new ModalDialogFormJsonResult(SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null)));
+
+            return viewModel.ProjectIsProposal.Value // a null value will have been caught by the validation
+                ? new ModalDialogFormJsonResult(
+                    SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null)))
+                : new ModalDialogFormJsonResult(
+                    SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsEnterHistoric(null)));
         }
 
         [LoggedInAndNotUnassignedRoleUnclassifiedFeature]
@@ -89,6 +94,28 @@ namespace ProjectFirma.Web.Controllers
             {
                 var viewData = new InstructionsProposalViewData(CurrentPerson, firmaPage, true);
                 return RazorView<InstructionsProposal, InstructionsProposalViewData>(viewData);
+            }
+        }
+
+        [LoggedInAndNotUnassignedRoleUnclassifiedFeature]
+        public ActionResult InstructionsEnterHistoric(int? projectID)
+        {
+            var firmaPageType = FirmaPageType.ToType(FirmaPageTypeEnum.EnterHistoricProjectInstructions);
+            var firmaPage = FirmaPage.GetFirmaPageByPageType(firmaPageType);
+
+            if (projectID.HasValue)
+            {
+                var project = HttpRequestStorage.DatabaseEntities.Projects.GetProject(projectID.Value);
+
+                var proposalSectionsStatus = new ProposalSectionsStatus(project);
+                var viewData = new InstructionsEnterHistoricViewData(CurrentPerson, project, proposalSectionsStatus, firmaPage, false);
+
+                return RazorView<InstructionsEnterHistoric, InstructionsEnterHistoricViewData>(viewData);
+            }
+            else
+            {
+                var viewData = new InstructionsEnterHistoricViewData(CurrentPerson, firmaPage, true);
+                return RazorView<InstructionsEnterHistoric, InstructionsEnterHistoricViewData>(viewData);
             }
         }
 

--- a/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
@@ -67,7 +67,7 @@ namespace ProjectFirma.Web.Controllers
             {
                 return RazorPartialView<ProjectTypeSelection, ProjectTypeSelectionViewData, ProjectTypeSelectionViewModel>(viewData, viewModel);
             }
-            return RazorPartialView<ProjectTypeSelection, ProjectTypeSelectionViewData, ProjectTypeSelectionViewModel>(viewData, viewModel);
+            return new ModalDialogFormJsonResult(SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(null)));
         }
 
         [LoggedInAndNotUnassignedRoleUnclassifiedFeature]

--- a/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
@@ -48,6 +48,28 @@ namespace ProjectFirma.Web.Controllers
 {
     public class ProjectCreateController : FirmaBaseController
     {
+        [HttpGet]
+        [LoggedInAndNotUnassignedRoleUnclassifiedFeature]
+        public PartialViewResult ProjectTypeSelection()
+        {
+            var viewData = new ProjectTypeSelectionViewData();
+            var viewModel = new ProjectTypeSelectionViewModel();
+            return RazorPartialView<ProjectTypeSelection, ProjectTypeSelectionViewData, ProjectTypeSelectionViewModel>(viewData, viewModel);
+        }
+
+        [HttpPost]
+        [LoggedInAndNotUnassignedRoleUnclassifiedFeature]
+        public ActionResult ProjectTypeSelection(ProjectTypeSelectionViewModel viewModel)
+        {
+            var viewData = new ProjectTypeSelectionViewData();
+
+            if (!ModelState.IsValid)
+            {
+                return RazorPartialView<ProjectTypeSelection, ProjectTypeSelectionViewData, ProjectTypeSelectionViewModel>(viewData, viewModel);
+            }
+            return RazorPartialView<ProjectTypeSelection, ProjectTypeSelectionViewData, ProjectTypeSelectionViewModel>(viewData, viewModel);
+        }
+
         [LoggedInAndNotUnassignedRoleUnclassifiedFeature]
         public ActionResult Instructions(int? projectID)
         {

--- a/Source/ProjectFirma.Web/Models/FirmaPageType.cs
+++ b/Source/ProjectFirma.Web/Models/FirmaPageType.cs
@@ -290,6 +290,13 @@ namespace ProjectFirma.Web.Models
             return SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null));
         }
     }
+    public partial class FirmaPageTypeEnterHistoricProjectInstructions
+    {
+        public override string GetViewUrl()
+        {
+            return SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsEnterHistoric(null));
+        }
+    }
 
     public partial class FirmaPageTypeProjectStewardOrganizationList
     {

--- a/Source/ProjectFirma.Web/Models/FirmaPageType.cs
+++ b/Source/ProjectFirma.Web/Models/FirmaPageType.cs
@@ -287,7 +287,7 @@ namespace ProjectFirma.Web.Models
     {
         public override string GetViewUrl()
         {
-            return SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(null));
+            return SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null));
         }
     }
 

--- a/Source/ProjectFirma.Web/Models/Generated/FirmaPageType.Binding.cs
+++ b/Source/ProjectFirma.Web/Models/Generated/FirmaPageType.Binding.cs
@@ -52,6 +52,7 @@ namespace ProjectFirma.Web.Models
         public static readonly FirmaPageTypeMonitoringProgramsList MonitoringProgramsList = FirmaPageTypeMonitoringProgramsList.Instance;
         public static readonly FirmaPageTypeProposeProjectInstructions ProposeProjectInstructions = FirmaPageTypeProposeProjectInstructions.Instance;
         public static readonly FirmaPageTypeProjectStewardOrganizationList ProjectStewardOrganizationList = FirmaPageTypeProjectStewardOrganizationList.Instance;
+        public static readonly FirmaPageTypeImportHistoricProjectInstructions ImportHistoricProjectInstructions = FirmaPageTypeImportHistoricProjectInstructions.Instance;
 
         public static readonly List<FirmaPageType> All;
         public static readonly ReadOnlyDictionary<int, FirmaPageType> AllLookupDictionary;
@@ -61,7 +62,7 @@ namespace ProjectFirma.Web.Models
         /// </summary>
         static FirmaPageType()
         {
-            All = new List<FirmaPageType> { HomePage, About, MeetingsandDocuments, DemoScript, InternalSetupNotes, FullProjectList, PerformanceMeasuresList, TaxonomyTierOneList, TaxonomyTierTwoList, TaxonomyTierThreeList, FundingSourcesList, OrganizationsList, WatershedsList, MyProjects, InvestmentByOrganizationType, SpendingByOrganizationTypeByTaxonomyTier, ProjectMap, ResultsByTaxonomyTierTwo, HomeMapInfo, HomeAdditionalInfo, FeaturedProjectList, CostParameterSet, FullProjectListSimple, Taxonomy, TagList, SpendingByPerformanceMeasureByProject, Proposals, MyOrganizationsProjects, ManageUpdateNotifications, ProjectUpdateStatus, ClassificationsList, MonitoringProgramsList, ProposeProjectInstructions, ProjectStewardOrganizationList };
+            All = new List<FirmaPageType> { HomePage, About, MeetingsandDocuments, DemoScript, InternalSetupNotes, FullProjectList, PerformanceMeasuresList, TaxonomyTierOneList, TaxonomyTierTwoList, TaxonomyTierThreeList, FundingSourcesList, OrganizationsList, WatershedsList, MyProjects, InvestmentByOrganizationType, SpendingByOrganizationTypeByTaxonomyTier, ProjectMap, ResultsByTaxonomyTierTwo, HomeMapInfo, HomeAdditionalInfo, FeaturedProjectList, CostParameterSet, FullProjectListSimple, Taxonomy, TagList, SpendingByPerformanceMeasureByProject, Proposals, MyOrganizationsProjects, ManageUpdateNotifications, ProjectUpdateStatus, ClassificationsList, MonitoringProgramsList, ProposeProjectInstructions, ProjectStewardOrganizationList, ImportHistoricProjectInstructions };
             AllLookupDictionary = new ReadOnlyDictionary<int, FirmaPageType>(All.ToDictionary(x => x.FirmaPageTypeID));
         }
 
@@ -155,6 +156,8 @@ namespace ProjectFirma.Web.Models
                     return HomeMapInfo;
                 case FirmaPageTypeEnum.HomePage:
                     return HomePage;
+                case FirmaPageTypeEnum.ImportHistoricProjectInstructions:
+                    return ImportHistoricProjectInstructions;
                 case FirmaPageTypeEnum.InternalSetupNotes:
                     return InternalSetupNotes;
                 case FirmaPageTypeEnum.InvestmentByOrganizationType:
@@ -242,7 +245,8 @@ namespace ProjectFirma.Web.Models
         ClassificationsList = 43,
         MonitoringProgramsList = 44,
         ProposeProjectInstructions = 45,
-        ProjectStewardOrganizationList = 46
+        ProjectStewardOrganizationList = 46,
+        ImportHistoricProjectInstructions = 47
     }
 
     public partial class FirmaPageTypeHomePage : FirmaPageType
@@ -447,5 +451,11 @@ namespace ProjectFirma.Web.Models
     {
         private FirmaPageTypeProjectStewardOrganizationList(int firmaPageTypeID, string firmaPageTypeName, string firmaPageTypeDisplayName, int firmaPageRenderTypeID) : base(firmaPageTypeID, firmaPageTypeName, firmaPageTypeDisplayName, firmaPageRenderTypeID) {}
         public static readonly FirmaPageTypeProjectStewardOrganizationList Instance = new FirmaPageTypeProjectStewardOrganizationList(46, @"ProjectStewardOrganizationList", @"ProjectStewardOrganizationList", 1);
+    }
+
+    public partial class FirmaPageTypeImportHistoricProjectInstructions : FirmaPageType
+    {
+        private FirmaPageTypeImportHistoricProjectInstructions(int firmaPageTypeID, string firmaPageTypeName, string firmaPageTypeDisplayName, int firmaPageRenderTypeID) : base(firmaPageTypeID, firmaPageTypeName, firmaPageTypeDisplayName, firmaPageRenderTypeID) {}
+        public static readonly FirmaPageTypeImportHistoricProjectInstructions Instance = new FirmaPageTypeImportHistoricProjectInstructions(47, @"ImportHistoricProjectInstructions", @"Import Historic Project Instructions", 2);
     }
 }

--- a/Source/ProjectFirma.Web/Models/Generated/FirmaPageType.Binding.cs
+++ b/Source/ProjectFirma.Web/Models/Generated/FirmaPageType.Binding.cs
@@ -52,7 +52,7 @@ namespace ProjectFirma.Web.Models
         public static readonly FirmaPageTypeMonitoringProgramsList MonitoringProgramsList = FirmaPageTypeMonitoringProgramsList.Instance;
         public static readonly FirmaPageTypeProposeProjectInstructions ProposeProjectInstructions = FirmaPageTypeProposeProjectInstructions.Instance;
         public static readonly FirmaPageTypeProjectStewardOrganizationList ProjectStewardOrganizationList = FirmaPageTypeProjectStewardOrganizationList.Instance;
-        public static readonly FirmaPageTypeImportHistoricProjectInstructions ImportHistoricProjectInstructions = FirmaPageTypeImportHistoricProjectInstructions.Instance;
+        public static readonly FirmaPageTypeEnterHistoricProjectInstructions EnterHistoricProjectInstructions = FirmaPageTypeEnterHistoricProjectInstructions.Instance;
 
         public static readonly List<FirmaPageType> All;
         public static readonly ReadOnlyDictionary<int, FirmaPageType> AllLookupDictionary;
@@ -62,7 +62,7 @@ namespace ProjectFirma.Web.Models
         /// </summary>
         static FirmaPageType()
         {
-            All = new List<FirmaPageType> { HomePage, About, MeetingsandDocuments, DemoScript, InternalSetupNotes, FullProjectList, PerformanceMeasuresList, TaxonomyTierOneList, TaxonomyTierTwoList, TaxonomyTierThreeList, FundingSourcesList, OrganizationsList, WatershedsList, MyProjects, InvestmentByOrganizationType, SpendingByOrganizationTypeByTaxonomyTier, ProjectMap, ResultsByTaxonomyTierTwo, HomeMapInfo, HomeAdditionalInfo, FeaturedProjectList, CostParameterSet, FullProjectListSimple, Taxonomy, TagList, SpendingByPerformanceMeasureByProject, Proposals, MyOrganizationsProjects, ManageUpdateNotifications, ProjectUpdateStatus, ClassificationsList, MonitoringProgramsList, ProposeProjectInstructions, ProjectStewardOrganizationList, ImportHistoricProjectInstructions };
+            All = new List<FirmaPageType> { HomePage, About, MeetingsandDocuments, DemoScript, InternalSetupNotes, FullProjectList, PerformanceMeasuresList, TaxonomyTierOneList, TaxonomyTierTwoList, TaxonomyTierThreeList, FundingSourcesList, OrganizationsList, WatershedsList, MyProjects, InvestmentByOrganizationType, SpendingByOrganizationTypeByTaxonomyTier, ProjectMap, ResultsByTaxonomyTierTwo, HomeMapInfo, HomeAdditionalInfo, FeaturedProjectList, CostParameterSet, FullProjectListSimple, Taxonomy, TagList, SpendingByPerformanceMeasureByProject, Proposals, MyOrganizationsProjects, ManageUpdateNotifications, ProjectUpdateStatus, ClassificationsList, MonitoringProgramsList, ProposeProjectInstructions, ProjectStewardOrganizationList, EnterHistoricProjectInstructions };
             AllLookupDictionary = new ReadOnlyDictionary<int, FirmaPageType>(All.ToDictionary(x => x.FirmaPageTypeID));
         }
 
@@ -142,6 +142,8 @@ namespace ProjectFirma.Web.Models
                     return CostParameterSet;
                 case FirmaPageTypeEnum.DemoScript:
                     return DemoScript;
+                case FirmaPageTypeEnum.EnterHistoricProjectInstructions:
+                    return EnterHistoricProjectInstructions;
                 case FirmaPageTypeEnum.FeaturedProjectList:
                     return FeaturedProjectList;
                 case FirmaPageTypeEnum.FullProjectList:
@@ -156,8 +158,6 @@ namespace ProjectFirma.Web.Models
                     return HomeMapInfo;
                 case FirmaPageTypeEnum.HomePage:
                     return HomePage;
-                case FirmaPageTypeEnum.ImportHistoricProjectInstructions:
-                    return ImportHistoricProjectInstructions;
                 case FirmaPageTypeEnum.InternalSetupNotes:
                     return InternalSetupNotes;
                 case FirmaPageTypeEnum.InvestmentByOrganizationType:
@@ -246,7 +246,7 @@ namespace ProjectFirma.Web.Models
         MonitoringProgramsList = 44,
         ProposeProjectInstructions = 45,
         ProjectStewardOrganizationList = 46,
-        ImportHistoricProjectInstructions = 47
+        EnterHistoricProjectInstructions = 47
     }
 
     public partial class FirmaPageTypeHomePage : FirmaPageType
@@ -453,9 +453,9 @@ namespace ProjectFirma.Web.Models
         public static readonly FirmaPageTypeProjectStewardOrganizationList Instance = new FirmaPageTypeProjectStewardOrganizationList(46, @"ProjectStewardOrganizationList", @"ProjectStewardOrganizationList", 1);
     }
 
-    public partial class FirmaPageTypeImportHistoricProjectInstructions : FirmaPageType
+    public partial class FirmaPageTypeEnterHistoricProjectInstructions : FirmaPageType
     {
-        private FirmaPageTypeImportHistoricProjectInstructions(int firmaPageTypeID, string firmaPageTypeName, string firmaPageTypeDisplayName, int firmaPageRenderTypeID) : base(firmaPageTypeID, firmaPageTypeName, firmaPageTypeDisplayName, firmaPageRenderTypeID) {}
-        public static readonly FirmaPageTypeImportHistoricProjectInstructions Instance = new FirmaPageTypeImportHistoricProjectInstructions(47, @"ImportHistoricProjectInstructions", @"Import Historic Project Instructions", 2);
+        private FirmaPageTypeEnterHistoricProjectInstructions(int firmaPageTypeID, string firmaPageTypeName, string firmaPageTypeDisplayName, int firmaPageRenderTypeID) : base(firmaPageTypeID, firmaPageTypeName, firmaPageTypeDisplayName, firmaPageRenderTypeID) {}
+        public static readonly FirmaPageTypeEnterHistoricProjectInstructions Instance = new FirmaPageTypeEnterHistoricProjectInstructions(47, @"EnterHistoricProjectInstructions", @"Enter Historic Project Instructions", 2);
     }
 }

--- a/Source/ProjectFirma.Web/Models/Generated/Project.DatabaseContextExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/Generated/Project.DatabaseContextExtensions.cs
@@ -44,47 +44,5 @@ namespace ProjectFirma.Web.Models
         {
             DeleteProject(new List<Project> { projectToDelete });
         }
-
-        public static List<int> GetProjectUpdateImplementationStartToCompletionYearRange(this IProject projectUpdate)
-        {
-            var startYear = projectUpdate?.ImplementationStartYear;
-            return GetYearRangesImpl(projectUpdate, startYear);
-        }
-
-        public static List<int> GetProjectUpdatePlanningDesignStartToCompletionYearRange(this IProject projectUpdate)
-        {
-            var startYear = projectUpdate?.PlanningDesignStartYear;
-            return GetYearRangesImpl(projectUpdate, startYear);
-        }
-
-        private static List<int> GetYearRangesImpl(IProject projectUpdate, int? startYear)
-        {
-            var currentYearToUse = FirmaDateUtilities.CalculateCurrentYearToUseForReporting();
-            if (projectUpdate != null)
-            {
-                if (startYear.HasValue && startYear.Value < FirmaDateUtilities.MinimumYear &&
-                    (projectUpdate.CompletionYear.HasValue && projectUpdate.CompletionYear.Value < FirmaDateUtilities.MinimumYear))
-                {
-                    // both start and completion year are before the minimum year, so no year range required
-                    return new List<int>();
-                }
-
-                if (startYear.HasValue && startYear.Value > currentYearToUse && (projectUpdate.CompletionYear.HasValue && projectUpdate.CompletionYear.Value > currentYearToUse))
-                {
-                    return new List<int>();
-                }
-
-                if (startYear.HasValue && projectUpdate.CompletionYear.HasValue && startYear.Value > projectUpdate.CompletionYear.Value)
-                {
-                    return new List<int>();
-                }
-            }
-            return FirmaDateUtilities.CalculateCalendarYearRangeAccountingForExistingYears(new List<int>(),
-                startYear,
-                projectUpdate?.CompletionYear,
-                currentYearToUse,
-                FirmaDateUtilities.MinimumYear,
-                currentYearToUse);
-        }
     }
 }

--- a/Source/ProjectFirma.Web/Models/NotificationProject.cs
+++ b/Source/ProjectFirma.Web/Models/NotificationProject.cs
@@ -168,7 +168,7 @@ Thank you,<br />
         {
             var submitterPerson = project.ProposingPerson;
             var subject = $"A Project Proposal was submitted by {submitterPerson.FullNameFirstLastAndOrg}";
-            var instructionsUrl = SitkaRoute<ProjectCreateController>.BuildAbsoluteUrlHttpsFromExpression(x => x.Instructions(project.ProjectID));
+            var instructionsUrl = SitkaRoute<ProjectCreateController>.BuildAbsoluteUrlHttpsFromExpression(x => x.InstructionsProposal(project.ProjectID));
             var message = $@"
 <p>A proposal was submitted for a new Project, “{project.DisplayName}”.</p>
 <p>The proposal was submitted on {project.ProposingDate.ToStringDate()} by {
@@ -226,7 +226,7 @@ Thank you,<br />
         {
             var submitterPerson = project.ProposingPerson;
             var subject = $@"Your Proposal ""{project.DisplayName.ToEllipsifiedString(80)}"" was not approved";
-            var instructionsUrl = SitkaRoute<ProjectCreateController>.BuildAbsoluteUrlHttpsFromExpression(x => x.Instructions(project.ProjectID));
+            var instructionsUrl = SitkaRoute<ProjectCreateController>.BuildAbsoluteUrlHttpsFromExpression(x => x.InstructionsProposal(project.ProjectID));
             var message = $@"
 <p>Dear {submitterPerson.FullNameFirstLast},</p>
 <p>The {MultiTenantHelpers.GetToolDisplayName()} Proposal submitted on {project.SubmissionDate.ToStringDate()} has been returned for further review.</p>

--- a/Source/ProjectFirma.Web/Models/ProjectCreateSection.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectCreateSection.cs
@@ -24,7 +24,7 @@ namespace ProjectFirma.Web.Models
 
         public override string GetSectionUrl(Project project)
         {
-            return SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(project != null ? project.ProjectID : (int?) null));
+            return SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(project != null ? project.ProjectID : (int?) null));
         }
     }
 

--- a/Source/ProjectFirma.Web/Models/ProjectCreateSection.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectCreateSection.cs
@@ -24,7 +24,20 @@ namespace ProjectFirma.Web.Models
 
         public override string GetSectionUrl(Project project)
         {
-            return SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(project != null ? project.ProjectID : (int?) null));
+            if (project == null)
+            {
+                return null;
+            }
+            else if (project.ProjectStage == ProjectStage.Proposal)
+            {
+                return SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x =>
+                    x.InstructionsProposal(project.ProjectID));
+            }
+            else
+            {
+                return SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x =>
+                    x.InstructionsEnterHistoric(project.ProjectID));
+            } 
         }
     }
 

--- a/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
@@ -18,6 +18,8 @@ GNU Affero General Public License <http://www.gnu.org/licenses/> for more detail
 Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*/
+
+using System.Collections.Generic;
 using ProjectFirma.Web.Controllers;
 using LtInfo.Common;
 using ProjectFirma.Web.Common;
@@ -73,5 +75,48 @@ namespace ProjectFirma.Web.Models
         {
             return ProjectMapPopuUrlTemplate.ParameterReplace(project.ProjectID);
         }
+
+        public static List<int> GetProjectUpdateImplementationStartToCompletionYearRange(this IProject projectUpdate)
+        {
+            var startYear = projectUpdate?.ImplementationStartYear;
+            return GetYearRangesImpl(projectUpdate, startYear);
+        }
+
+        public static List<int> GetProjectUpdatePlanningDesignStartToCompletionYearRange(this IProject projectUpdate)
+        {
+            var startYear = projectUpdate?.PlanningDesignStartYear;
+            return GetYearRangesImpl(projectUpdate, startYear);
+        }
+
+        private static List<int> GetYearRangesImpl(IProject projectUpdate, int? startYear)
+        {
+            var currentYearToUse = FirmaDateUtilities.CalculateCurrentYearToUseForReporting();
+            if (projectUpdate != null)
+            {
+                if (startYear.HasValue && startYear.Value < FirmaDateUtilities.MinimumYear &&
+                    (projectUpdate.CompletionYear.HasValue && projectUpdate.CompletionYear.Value < FirmaDateUtilities.MinimumYear))
+                {
+                    // both start and completion year are before the minimum year, so no year range required
+                    return new List<int>();
+                }
+
+                if (startYear.HasValue && startYear.Value > currentYearToUse && (projectUpdate.CompletionYear.HasValue && projectUpdate.CompletionYear.Value > currentYearToUse))
+                {
+                    return new List<int>();
+                }
+
+                if (startYear.HasValue && projectUpdate.CompletionYear.HasValue && startYear.Value > projectUpdate.CompletionYear.Value)
+                {
+                    return new List<int>();
+                }
+            }
+            return FirmaDateUtilities.CalculateCalendarYearRangeAccountingForExistingYears(new List<int>(),
+                startYear,
+                projectUpdate?.CompletionYear,
+                currentYearToUse,
+                FirmaDateUtilities.MinimumYear,
+                currentYearToUse);
+        }
+
     }
 }

--- a/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
+++ b/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
@@ -379,6 +379,8 @@
     <Compile Include="Views\PerformanceMeasure\DownloadChartDataViewModel.cs" />
     <Compile Include="Views\PerformanceMeasure\GoogleChartExcelSpec.cs" />
     <Compile Include="Views\PerformanceMeasure\PerformanceMeasureChartExcelSpec.cs" />
+    <Compile Include="Views\ProjectCreate\InstructionsEnterHistoric.cs" />
+    <Compile Include="Views\ProjectCreate\InstructionsEnterHistoricViewData.cs" />
     <Compile Include="Views\ProjectCreate\ProjectTypeSelection.cs" />
     <Compile Include="Views\ProjectCreate\ProjectTypeSelectionViewData.cs" />
     <Compile Include="Views\ProjectCreate\ProjectTypeSelectionViewModel.cs" />
@@ -1382,6 +1384,7 @@
     <Content Include="Views\ProjectCreate\Expenditures.cshtml" />
     <Content Include="Views\ProjectCreate\PerformanceMeasures.cshtml" />
     <Content Include="Views\ProjectCreate\ProjectTypeSelection.cshtml" />
+    <Content Include="Views\ProjectCreate\InstructionsEnterHistoric.cshtml" />
     <Reference Include="Antlr3.Runtime">
       <HintPath>..\NuGetPackages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>

--- a/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
+++ b/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
@@ -379,6 +379,9 @@
     <Compile Include="Views\PerformanceMeasure\DownloadChartDataViewModel.cs" />
     <Compile Include="Views\PerformanceMeasure\GoogleChartExcelSpec.cs" />
     <Compile Include="Views\PerformanceMeasure\PerformanceMeasureChartExcelSpec.cs" />
+    <Compile Include="Views\ProjectCreate\ProjectTypeSelection.cs" />
+    <Compile Include="Views\ProjectCreate\ProjectTypeSelectionViewData.cs" />
+    <Compile Include="Views\ProjectCreate\ProjectTypeSelectionViewModel.cs" />
     <Compile Include="Views\ProjectCreate\ExpectedFunding.cs" />
     <Compile Include="Views\ProjectCreate\ExpectedFundingViewData.cs" />
     <Compile Include="Views\ProjectCreate\ExpectedFundingViewModel.cs" />
@@ -1378,6 +1381,7 @@
     <Content Include="Views\Project\Pending.cshtml" />
     <Content Include="Views\ProjectCreate\Expenditures.cshtml" />
     <Content Include="Views\ProjectCreate\PerformanceMeasures.cshtml" />
+    <Content Include="Views\ProjectCreate\ProjectTypeSelection.cshtml" />
     <Reference Include="Antlr3.Runtime">
       <HintPath>..\NuGetPackages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>

--- a/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
+++ b/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
@@ -1161,8 +1161,8 @@
     <Compile Include="Views\ProjectCreate\ExpectedPerformanceMeasureValuesViewModel.cs" />
     <Compile Include="Views\Project\Proposed.cs" />
     <Compile Include="Views\Project\ProposedViewData.cs" />
-    <Compile Include="Views\ProjectCreate\Instructions.cs" />
-    <Compile Include="Views\ProjectCreate\InstructionsViewData.cs" />
+    <Compile Include="Views\ProjectCreate\InstructionsProposal.cs" />
+    <Compile Include="Views\ProjectCreate\InstructionsProposalViewData.cs" />
     <Compile Include="Views\ProjectCreate\LocationDetailed.cs" />
     <Compile Include="Views\ProjectCreate\LocationDetailedViewData.cs" />
     <Compile Include="Views\ProjectCreate\LocationDetailedViewModel.cs" />
@@ -3234,7 +3234,7 @@
     <Content Include="Views\ProjectCreate\EditProposalClassifications.cshtml" />
     <Content Include="Views\ProjectCreate\ExpectedPerformanceMeasureValues.cshtml" />
     <Content Include="Views\Project\Proposed.cshtml" />
-    <Content Include="Views\ProjectCreate\Instructions.cshtml" />
+    <Content Include="Views\ProjectCreate\InstructionsProposal.cshtml" />
     <Content Include="Views\ProjectCreate\LocationDetailed.cshtml" />
     <Content Include="Views\ProjectCreate\LocationSimple.cshtml" />
     <Content Include="Views\ProjectCreate\Notes.cshtml" />

--- a/Source/ProjectFirma.Web/Views/Home/Index.cshtml
+++ b/Source/ProjectFirma.Web/Views/Home/Index.cshtml
@@ -141,7 +141,7 @@
         <div class="col-md-4">
             @if (ViewDataTyped.DisplayActionButtons)
             {            
-                @ModalDialogFormHelper.ModalDialogFormLink(ViewDataTyped.AddNewProjectButtonText,ViewDataTyped.ProjectTypeSelectionUrl,"Add a new project",500,ViewDataTyped.ProjectTypeSelectionContinueButtonText,"Cancel",new List<string>{"btn", "btn-firma"},null,null)
+                @ModalDialogFormHelper.ModalDialogFormLink(ViewDataTyped.AddNewProjectButtonText,ViewDataTyped.ProjectTypeSelectionUrl,"Add a new project",700,ViewDataTyped.ProjectTypeSelectionContinueButtonText,"Cancel",new List<string>{"btn", "btn-firma"},null,null)
                 <a class="btn btn-firma" href="@ViewDataTyped.ProjectUpdatesUrl" title="View projects requiring an update">@BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-edit") Update Existing Project</a>
             }
             <h4 style="margin-bottom: 5px; margin-top: 10px;">@FieldDefinition.Project.GetFieldDefinitionLabel() Map</h4>

--- a/Source/ProjectFirma.Web/Views/Home/Index.cshtml
+++ b/Source/ProjectFirma.Web/Views/Home/Index.cshtml
@@ -141,8 +141,8 @@
         <div class="col-md-4">
             @if (ViewDataTyped.DisplayActionButtons)
             {            
-                @ModalDialogFormHelper.ModalDialogFormLink(ViewDataTyped.AddNewProjectButtonText,ViewDataTyped.ProjectTypeSelectionUrl,"Add a new project",700,ViewDataTyped.ProjectTypeSelectionContinueButtonText,"Cancel",new List<string>{"btn", "btn-firma"},null,null)
-                <a class="btn btn-firma" href="@ViewDataTyped.ProjectUpdatesUrl" title="View projects requiring an update">@BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-edit") Update Existing Project</a>
+                @ModalDialogFormHelper.ModalDialogFormLink(ViewDataTyped.AddNewProjectButtonText,ViewDataTyped.ProjectTypeSelectionUrl,"Add a project",700,ViewDataTyped.ProjectTypeSelectionContinueButtonText,"Cancel",new List<string>{"btn", "btn-firma"},null,null)
+                <a class="btn btn-firma" href="@ViewDataTyped.ProjectUpdatesUrl" title="View projects requiring an update">@BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-edit") Update Project</a>
             }
             <h4 style="margin-bottom: 5px; margin-top: 10px;">@FieldDefinition.Project.GetFieldDefinitionLabel() Map</h4>
             <div>

--- a/Source/ProjectFirma.Web/Views/Home/Index.cshtml
+++ b/Source/ProjectFirma.Web/Views/Home/Index.cshtml
@@ -19,6 +19,7 @@
     </license>
     -----------------------------------------------------------------------*@
 @using LtInfo.Common.BootstrapWrappers
+@using LtInfo.Common.ModalDialog
 @using Newtonsoft.Json
 @using Newtonsoft.Json.Linq
 @using ProjectFirma.Web.Models
@@ -139,11 +140,11 @@
 
         <div class="col-md-4">
             @if (ViewDataTyped.DisplayActionButtons)
-            {
-                <a class="btn btn-firma" style="margin-bottom: 10px" href="@ViewDataTyped.ProposeNewProjectUrl" title="Propose a new project">@BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-plus") Add New Project</a>
-                <a class="btn btn-firma" style="margin-bottom: 10px" href="@ViewDataTyped.ProjectUpdatesUrl" title="View projects requiring an update">@BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-edit") Update Existing Project</a>
+            {            
+                @ModalDialogFormHelper.ModalDialogFormLink(ViewDataTyped.AddNewProjectButtonText,ViewDataTyped.ProjectTypeSelectionUrl,"Add a new project",500,ViewDataTyped.ProjectTypeSelectionContinueButtonText,"Cancel",new List<string>{"btn", "btn-firma"},null,null)
+                <a class="btn btn-firma" href="@ViewDataTyped.ProjectUpdatesUrl" title="View projects requiring an update">@BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-edit") Update Existing Project</a>
             }
-            <h4 style="margin-bottom: 5px;">@FieldDefinition.Project.GetFieldDefinitionLabel() Map</h4>
+            <h4 style="margin-bottom: 5px; margin-top: 10px;">@FieldDefinition.Project.GetFieldDefinitionLabel() Map</h4>
             <div>
                 @{ ViewPageContent.RenderPartialView(Html, ViewDataTyped.CustomHomePageMapTextViewData); }
             </div>

--- a/Source/ProjectFirma.Web/Views/Home/IndexViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Home/IndexViewData.cs
@@ -67,7 +67,7 @@ namespace ProjectFirma.Web.Views.Home
             SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.ProjectTypeSelection());
 
         public string AddNewProjectButtonText =
-            $"{BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-plus")} Add New Project";
+            $"{BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-plus")} Add Project";
 
         public string ProjectTypeSelectionContinueButtonText =
             $"Continue {BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-chevron-right")}";

--- a/Source/ProjectFirma.Web/Views/Home/IndexViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Home/IndexViewData.cs
@@ -58,7 +58,7 @@ namespace ProjectFirma.Web.Views.Home
             ProjectLocationsMapViewData = projectLocationsMapViewData;
             ProjectLocationsMapInitJson = projectLocationsMapInitJson;
             FirmaHomePageCarouselImages = firmaHomePageImages;
-            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(null));
+            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null));
             ProjectUpdatesUrl = SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.MyProjectsRequiringAnUpdate());
             DisplayActionButtons = !currentPerson.IsAnonymousOrUnassigned;
         }

--- a/Source/ProjectFirma.Web/Views/Home/IndexViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Home/IndexViewData.cs
@@ -20,6 +20,7 @@ Source code is available upon request via <support@sitkatech.com>.
 -----------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using LtInfo.Common.BootstrapWrappers;
 using ProjectFirma.Web.Common;
 using ProjectFirma.Web.Controllers;
 using ProjectFirma.Web.Models;
@@ -61,5 +62,14 @@ namespace ProjectFirma.Web.Views.Home
             ProjectUpdatesUrl = SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.MyProjectsRequiringAnUpdate());
             DisplayActionButtons = !currentPerson.IsAnonymousOrUnassigned;
         }
+
+        public string ProjectTypeSelectionUrl =
+            SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.ProjectTypeSelection());
+
+        public string AddNewProjectButtonText =
+            $"{BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-plus")} Add New Project";
+
+        public string ProjectTypeSelectionContinueButtonText =
+            $"Continue {BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-chevron-right")}";
     }
 }

--- a/Source/ProjectFirma.Web/Views/Project/IndexViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/IndexViewData.cs
@@ -54,7 +54,7 @@ namespace ProjectFirma.Web.Views.Project
             GridName = "projectsGrid";
             GridDataUrl = SitkaRoute<ProjectController>.BuildUrlFromExpression(tc => tc.IndexGridJsonData());
 
-            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(null));
+            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null));
             ProjectUpdatesUrl = SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.MyProjectsRequiringAnUpdate());
             DisplayActionButtons = !currentPerson.IsAnonymousOrUnassigned;
         }

--- a/Source/ProjectFirma.Web/Views/Project/MyOrganizationsProjectsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/MyOrganizationsProjectsViewData.cs
@@ -62,7 +62,7 @@ namespace ProjectFirma.Web.Views.Project
             };
             ProposalsGridDataUrl = SitkaRoute<ProjectController>.BuildUrlFromExpression(tc => tc.MyOrganizationsProposalsGridJsonData());
 
-            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(tc => tc.Instructions(null));
+            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(tc => tc.InstructionsProposal(null));
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Project/PendingViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/PendingViewData.cs
@@ -39,7 +39,7 @@ namespace ProjectFirma.Web.Views.Project
             PageTitle = "Pending Projects";
 
             HasProposeProjectPermissions = new ProjectCreateFeature().HasPermissionByPerson(CurrentPerson);
-            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(null));
+            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null));
 
 
             GridSpec = new PendingGridSpec(currentPerson) {ObjectNameSingular = $"Pending Project", ObjectNamePlural = $"Pending Projects", SaveFiltersInCookie = true};

--- a/Source/ProjectFirma.Web/Views/Project/ProposedViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ProposedViewData.cs
@@ -39,7 +39,7 @@ namespace ProjectFirma.Web.Views.Project
             PageTitle = Models.FieldDefinition.Proposal.GetFieldDefinitionLabelPluralized();
 
             HasProposeProjectPermissions = new ProjectCreateFeature().HasPermissionByPerson(CurrentPerson);
-            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(null));
+            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null));
 
 
             GridSpec = new ProposalsGridSpec(currentPerson) {ObjectNameSingular = $"{Models.FieldDefinition.Proposal.GetFieldDefinitionLabel()}", ObjectNamePlural = $"{Models.FieldDefinition.Proposal.GetFieldDefinitionLabelPluralized()}", SaveFiltersInCookie = true};

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoric.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoric.cs
@@ -1,5 +1,5 @@
 ﻿/*-----------------------------------------------------------------------
-<copyright file="InstructionsProposal.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+<copyright file="InstructionsEnterHistoric.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
 Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
 <author>Sitka Technology Group</author>
 </copyright>
@@ -20,7 +20,7 @@ Source code is available upon request via <support@sitkatech.com>.
 -----------------------------------------------------------------------*/
 namespace ProjectFirma.Web.Views.ProjectCreate
 {
-    public abstract class InstructionsProposal : LtInfo.Common.Mvc.TypedWebViewPage<InstructionsProposalViewData>
+    public abstract class InstructionsEnterHistoric : LtInfo.Common.Mvc.TypedWebViewPage<InstructionsEnterHistoricViewData>
     {
     }
 }

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoric.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoric.cshtml
@@ -1,5 +1,5 @@
 ﻿@*-----------------------------------------------------------------------
-<copyright file="Instructions.cshtml" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+<copyright file="InstructionsEnterHistoric.cshtml" company="Tahoe Regional Planning Agency and Sitka Technology Group">
 Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
 <author>Sitka Technology Group</author>
 </copyright>
@@ -19,7 +19,7 @@ Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*@
 @using ProjectFirma.Web.Views.Shared
-@inherits ProjectFirma.Web.Views.ProjectCreate.InstructionsProposal
+@inherits ProjectFirma.Web.Views.ProjectCreate.InstructionsEnterHistoric
 
 @section JavascriptAndStylesContent
 {
@@ -50,7 +50,7 @@ Source code is available upon request via <support@sitkatech.com>.
     {
         if (ViewDataTyped.IsNewProjectCreate)
         {
-            <a class="btn btn-xs btn-firma" href="@ViewDataTyped.ProposalBasicsUrl">Propose New Project <span class='glyphicon glyphicon-chevron-right'></span></a>
+            <a class="btn btn-xs btn-firma" href="@ViewDataTyped.HistoricProjectBasicsUrl">Enter Historic Project <span class='glyphicon glyphicon-chevron-right'></span></a>
         }
         else
         {

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoricViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoricViewData.cs
@@ -1,0 +1,44 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="InstructionsEnterHistoricViewData.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+using ProjectFirma.Web.Models;
+using ProjectFirma.Web.Views.Shared;
+
+namespace ProjectFirma.Web.Views.ProjectCreate
+{
+    public class InstructionsEnterHistoricViewData : ProjectCreateViewData
+    {
+
+        public readonly bool IsNewProjectCreate;
+
+        public readonly ViewPageContentViewData InstructionsViewPageContentViewData;
+        public InstructionsEnterHistoricViewData(Person currentPerson, Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentPerson, ProjectCreateSection.Instructions)
+        {
+            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, currentPerson);
+            IsNewProjectCreate = isNewProjectCreate;
+        }
+
+        public InstructionsEnterHistoricViewData(Person currentPerson, Models.Project project, ProposalSectionsStatus proposalSectionsStatus, Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentPerson, project, ProjectCreateSection.Instructions, proposalSectionsStatus)
+        {
+            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, currentPerson);
+            IsNewProjectCreate = isNewProjectCreate;
+        }
+    }
+}

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposal.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposal.cs
@@ -20,7 +20,7 @@ Source code is available upon request via <support@sitkatech.com>.
 -----------------------------------------------------------------------*/
 namespace ProjectFirma.Web.Views.ProjectCreate
 {
-    public abstract class Instructions : LtInfo.Common.Mvc.TypedWebViewPage<InstructionsViewData>
+    public abstract class InstructionsProposal : LtInfo.Common.Mvc.TypedWebViewPage<InstructionsProposalViewData>
     {
     }
 }

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposal.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposal.cshtml
@@ -19,7 +19,7 @@ Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*@
 @using ProjectFirma.Web.Views.Shared
-@inherits ProjectFirma.Web.Views.ProjectCreate.Instructions
+@inherits ProjectFirma.Web.Views.ProjectCreate.InstructionsProposal
 
 @section JavascriptAndStylesContent
 {

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposalViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposalViewData.cs
@@ -23,19 +23,19 @@ using ProjectFirma.Web.Views.Shared;
 
 namespace ProjectFirma.Web.Views.ProjectCreate
 {
-    public class InstructionsViewData : ProjectCreateViewData
+    public class InstructionsProposalViewData : ProjectCreateViewData
     {
 
         public readonly bool IsNewProjectCreate;
 
         public readonly ViewPageContentViewData InstructionsViewPageContentViewData;
-        public InstructionsViewData(Person currentPerson, Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentPerson, ProjectCreateSection.Instructions)
+        public InstructionsProposalViewData(Person currentPerson, Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentPerson, ProjectCreateSection.Instructions)
         {
             InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, currentPerson);
             IsNewProjectCreate = isNewProjectCreate;
         }
 
-        public InstructionsViewData(Person currentPerson, Models.Project project, ProposalSectionsStatus proposalSectionsStatus, Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentPerson, project, ProjectCreateSection.Instructions, proposalSectionsStatus)
+        public InstructionsProposalViewData(Person currentPerson, Models.Project project, ProposalSectionsStatus proposalSectionsStatus, Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentPerson, project, ProjectCreateSection.Instructions, proposalSectionsStatus)
         {
             InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, currentPerson);
             IsNewProjectCreate = isNewProjectCreate;

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectCreateViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectCreateViewData.cs
@@ -93,7 +93,7 @@ namespace ProjectFirma.Web.Views.ProjectCreate
             PageTitle = $"{AddNewProject}: {project.DisplayName}";
 
             ProposalDetailUrl = SitkaRoute<ProjectController>.BuildUrlFromExpression(x => x.Detail(project));
-            ProposalInstructionsUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(project.ProjectID));
+            ProposalInstructionsUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(project.ProjectID));
             ProposalBasicsUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.EditBasics(project.ProjectID));
             ProposalPerformanceMeasuresUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.EditExpectedPerformanceMeasureValues(project));
             ProposalLocationSimpleUrl =  SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.EditLocationSimple(project));
@@ -128,7 +128,7 @@ namespace ProjectFirma.Web.Views.ProjectCreate
             PageTitle = AddNewProject;
             
 
-            ProposalInstructionsUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Instructions(null));
+            ProposalInstructionsUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null));
             ProposalBasicsUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.CreateAndEditBasics(true));
             HistoricProjectBasicsUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.CreateAndEditBasics(false));
             ProposalPerformanceMeasuresUrl = string.Empty;

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cs
@@ -1,0 +1,26 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="ProjectTypeSelection.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+namespace ProjectFirma.Web.Views.ProjectCreate
+{
+    public abstract class ProjectTypeSelection : LtInfo.Common.Mvc.TypedWebPartialViewPage<ProjectTypeSelectionViewData, ProjectTypeSelectionViewModel>
+    {
+    }
+}

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
@@ -18,7 +18,12 @@
     Source code is available upon request via <support@sitkatech.com>.
     </license>
     -----------------------------------------------------------------------*@
-@using ProjectFirma.Web.Models
-@using LtInfo.Common.HtmlHelperExtensions
-@using Newtonsoft.Json.Linq
 @inherits ProjectFirma.Web.Views.ProjectCreate.ProjectTypeSelection
+
+@using (Html.BeginForm())
+{
+    <div>
+        @Html.ValidationMessageFor(m=>m.ProjectIsProposal)
+        Hello, World!
+    </div>
+}

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
@@ -22,8 +22,8 @@
 
 @using (Html.BeginForm())
 {
+    @Html.ValidationSummary()
     <div>
-        @Html.ValidationMessageFor(m => m.ProjectIsProposal)
         Do you want to:
     </div>
     <div class="form-group">

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
@@ -31,13 +31,13 @@
             <label>
                 @Html.RadioButtonFor(m => m.ProjectIsProposal, true) <span style="font-weight: bold;">Add a proposal for a future project</span>
             </label>
-            <div class="systemText" style="margin-left: 7px;">This will create a new project in the Proposal stage. When a proposal is revied and selected for implementation an administrator can advance the project to the Planning/Design stage.</div>
+            <div class="systemText">This will create a new project in Proposal stage. When a proposal is reviewed and selected for implementation an administrator can advance the project to the Planning/Design stage.</div>
         </div>
         <div class="radio" style="margin-top: 10px;">
             <label>
-                @Html.RadioButtonFor(m => m.ProjectIsProposal, false) <span style="font-weight: bold;">Import an existing project that is already underway or complete</span>
+                @Html.RadioButtonFor(m => m.ProjectIsProposal, false) <span style="font-weight: bold;">Enter an existing project that is already underway or complete</span>
             </label>
-            <div class="systemText" style="margin-left: 7px;">This will create a new project record for an existing project. You will be asked to select the project stage (e.g. Planning/Design, Implementation, or Complete). An administrator will review the project before it becomes part of the official project record.</div>
+            <div class="systemText">This will create a new project record for an existing project. You will be asked to select the project stage (e.g. Planning/Design, Implementation, or Complete). An administrator will review the project before it becomes publicly visible.</div>
         </div>
     </div>
 }

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
@@ -1,0 +1,24 @@
+﻿@*-----------------------------------------------------------------------
+    <copyright file="ProjectTypeSelection.cshtml" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+    Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+    <author>Sitka Technology Group</author>
+    </copyright>
+
+    <license>
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+    Source code is available upon request via <support@sitkatech.com>.
+    </license>
+    -----------------------------------------------------------------------*@
+@using ProjectFirma.Web.Models
+@using LtInfo.Common.HtmlHelperExtensions
+@using Newtonsoft.Json.Linq
+@inherits ProjectFirma.Web.Views.ProjectCreate.ProjectTypeSelection

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelection.cshtml
@@ -23,7 +23,21 @@
 @using (Html.BeginForm())
 {
     <div>
-        @Html.ValidationMessageFor(m=>m.ProjectIsProposal)
-        Hello, World!
+        @Html.ValidationMessageFor(m => m.ProjectIsProposal)
+        Do you want to:
+    </div>
+    <div class="form-group">
+        <div class="radio">
+            <label>
+                @Html.RadioButtonFor(m => m.ProjectIsProposal, true) <span style="font-weight: bold;">Add a proposal for a future project</span>
+            </label>
+            <div class="systemText" style="margin-left: 7px;">This will create a new project in the Proposal stage. When a proposal is revied and selected for implementation an administrator can advance the project to the Planning/Design stage.</div>
+        </div>
+        <div class="radio" style="margin-top: 10px;">
+            <label>
+                @Html.RadioButtonFor(m => m.ProjectIsProposal, false) <span style="font-weight: bold;">Import an existing project that is already underway or complete</span>
+            </label>
+            <div class="systemText" style="margin-left: 7px;">This will create a new project record for an existing project. You will be asked to select the project stage (e.g. Planning/Design, Implementation, or Complete). An administrator will review the project before it becomes part of the official project record.</div>
+        </div>
     </div>
 }

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewData.cs
@@ -1,0 +1,32 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="ProjectTypeSelectionViewData.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+using System.Collections.Generic;
+using ProjectFirma.Web.Models;
+using ProjectFirma.Web.Views;
+
+namespace ProjectFirma.Web.Views.ProjectCreate
+{
+    public class ProjectTypeSelectionViewData : FirmaUserControlViewData
+    {
+       
+
+    }
+}

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewData.cs
@@ -26,7 +26,9 @@ namespace ProjectFirma.Web.Views.ProjectCreate
 {
     public class ProjectTypeSelectionViewData : FirmaUserControlViewData
     {
-       
-
+        public ProjectTypeSelectionViewData()
+        {
+            // todo: what goes here?
+        }
     }
 }

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewModel.cs
@@ -18,23 +18,22 @@ GNU Affero General Public License <http://www.gnu.org/licenses/> for more detail
 Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*/
-using System.Collections.Generic;
-using System.Linq;
-using ProjectFirma.Web.Models;
-using LtInfo.Common;
+
+using System.ComponentModel.DataAnnotations;
 using LtInfo.Common.Models;
 
 namespace ProjectFirma.Web.Views.ProjectCreate
 {
     public class ProjectTypeSelectionViewModel : FormViewModel
     {
-      
+        //[Required]
+        public int ProjectIsProposal { get; set; }
+
         /// <summary>
         /// Needed by the ModelBinder
         /// </summary>
         public ProjectTypeSelectionViewModel()
         {
         }
-
     }
 }

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewModel.cs
@@ -1,0 +1,40 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="ProjectTypeSelectionViewModel.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+using System.Collections.Generic;
+using System.Linq;
+using ProjectFirma.Web.Models;
+using LtInfo.Common;
+using LtInfo.Common.Models;
+
+namespace ProjectFirma.Web.Views.ProjectCreate
+{
+    public class ProjectTypeSelectionViewModel : FormViewModel
+    {
+      
+        /// <summary>
+        /// Needed by the ModelBinder
+        /// </summary>
+        public ProjectTypeSelectionViewModel()
+        {
+        }
+
+    }
+}

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ProjectTypeSelectionViewModel.cs
@@ -19,21 +19,34 @@ Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*/
 
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using LtInfo.Common.Models;
 
 namespace ProjectFirma.Web.Views.ProjectCreate
 {
-    public class ProjectTypeSelectionViewModel : FormViewModel
+    public class ProjectTypeSelectionViewModel : FormViewModel, IValidatableObject
     {
-        //[Required]
-        public int ProjectIsProposal { get; set; }
+        public bool? ProjectIsProposal { get; set; }
 
         /// <summary>
         /// Needed by the ModelBinder
         /// </summary>
         public ProjectTypeSelectionViewModel()
         {
+        }
+
+        // Chose this validation pattern instead of the RequiredAttribute because the qtip validation message is unfriendly
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            var errors = new List<ValidationResult>();
+            if (ProjectIsProposal == null)
+            {
+                errors.Add(new ValidationResult("You must select an option in order to proceed."));
+            }
+
+            return errors;
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
@@ -81,7 +81,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
             MySubmittedProjectsUrl = SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(tc => tc.MySubmittedProjects());
             AllProjectsUrl = SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(tc => tc.AllProjects());
             SubmittedProjectsUrl = SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(tc => tc.SubmittedProjects());
-            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(tc => tc.Instructions(null));
+            ProposeNewProjectUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(tc => tc.InstructionsProposal(null));
 
             HasProjectUpdateAdminPermissions = new ProjectUpdateAdminFeature().HasPermissionByPerson(CurrentPerson);
             HasProposeProjectPermissions = new ProjectCreateFeature().HasPermissionByPerson(CurrentPerson);


### PR DESCRIPTION
Adds a new modal dialog that follows the "Add Project" button and prompts the user to select if they're proposing a new project or entering one that already happened is happening. The "Instructions" section is now handled by two different routes in order to facilitate this.