### PR TITLE
Features/1313 clean up tenant configuration editor

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/TenantController.cs
+++ b/Source/ProjectFirma.Web/Controllers/TenantController.cs
@@ -48,6 +48,7 @@ namespace ProjectFirma.Web.Controllers
             var editBoundingBoxUrl = new SitkaRoute<TenantController>(c => c.EditBoundingBox()).BuildUrlFromExpression();
             var editClassificationSystemsUrl = new SitkaRoute<TenantController>(c => c.EditClassificationSystems()).BuildUrlFromExpression();
             var editStylesheetUrl = new SitkaRoute<TenantController>(c => c.EditStylesheet()).BuildUrlFromExpression();
+            var editTenantLogoUrl = new SitkaRoute<TenantController>(c => c.EditTenantLogo()).BuildUrlFromExpression();
             var deleteTenantStyleSheetFileResourceUrl = new SitkaRoute<TenantController>(c => c.DeleteTenantStyleSheetFileResource()).BuildUrlFromExpression();
             var deleteTenantSquareLogoFileResourceUrl = new SitkaRoute<TenantController>(c => c.DeleteTenantSquareLogoFileResource()).BuildUrlFromExpression();
             var deleteTenantBannerLogoFileResourceUrl = new SitkaRoute<TenantController>(c => c.DeleteTenantBannerLogoFileResource()).BuildUrlFromExpression();
@@ -80,7 +81,8 @@ namespace ProjectFirma.Web.Controllers
                 gridName,
                 gridDataUrl, 
                 editClassificationSystemsUrl,
-                editStylesheetUrl);
+                editStylesheetUrl,
+                editTenantLogoUrl);
             return RazorView<Detail, DetailViewData>(viewData);
         }
 
@@ -203,6 +205,39 @@ namespace ProjectFirma.Web.Controllers
         {
             var viewData = new EditStylesheetViewData(CurrentPerson);
             return RazorPartialView<EditStylesheet, EditStylesheetViewData, EditStylesheetViewModel>(viewData, viewModel);
+        }
+
+
+        [HttpGet]
+        [SitkaAdminFeature]
+        public PartialViewResult EditTenantLogo()
+        {
+            var tenant = HttpRequestStorage.Tenant;
+            var viewModel = new EditTenantLogoViewModel(tenant);
+            return ViewEditTenantLogo(viewModel);
+        }
+
+        [HttpPost]
+        [SitkaAdminFeature]
+        [AutomaticallyCallEntityFrameworkSaveChangesWhenModelValid]
+        public ActionResult EditTenantLogo(EditTenantLogoViewModel viewModel)
+        {
+            if (!ModelState.IsValid)
+            {
+                return ViewEditTenantLogo(viewModel);
+            }
+
+            var tenantAttribute = HttpRequestStorage.DatabaseEntities.AllTenantAttributes.Single(a => a.TenantID == viewModel.TenantID);
+
+            viewModel.UpdateModel(tenantAttribute, CurrentPerson);
+
+            return new ModalDialogFormJsonResult(new SitkaRoute<TenantController>(c => c.Detail()).BuildUrlFromExpression());
+        }
+
+        private PartialViewResult ViewEditTenantLogo(EditTenantLogoViewModel viewModel)
+        {
+            var viewData = new EditTenantLogoViewData(CurrentPerson);
+            return RazorPartialView<EditTenantLogo, EditTenantLogoViewData, EditTenantLogoViewModel>(viewData, viewModel);
         }
 
         [HttpGet]

--- a/Source/ProjectFirma.Web/Controllers/TenantController.cs
+++ b/Source/ProjectFirma.Web/Controllers/TenantController.cs
@@ -47,6 +47,7 @@ namespace ProjectFirma.Web.Controllers
             var editBasicsUrl = new SitkaRoute<TenantController>(c => c.EditBasics()).BuildUrlFromExpression();
             var editBoundingBoxUrl = new SitkaRoute<TenantController>(c => c.EditBoundingBox()).BuildUrlFromExpression();
             var editClassificationSystemsUrl = new SitkaRoute<TenantController>(c => c.EditClassificationSystems()).BuildUrlFromExpression();
+            var editStylesheetUrl = new SitkaRoute<TenantController>(c => c.EditStylesheet()).BuildUrlFromExpression();
             var deleteTenantStyleSheetFileResourceUrl = new SitkaRoute<TenantController>(c => c.DeleteTenantStyleSheetFileResource()).BuildUrlFromExpression();
             var deleteTenantSquareLogoFileResourceUrl = new SitkaRoute<TenantController>(c => c.DeleteTenantSquareLogoFileResource()).BuildUrlFromExpression();
             var deleteTenantBannerLogoFileResourceUrl = new SitkaRoute<TenantController>(c => c.DeleteTenantBannerLogoFileResource()).BuildUrlFromExpression();
@@ -78,7 +79,8 @@ namespace ProjectFirma.Web.Controllers
                 gridSpec,
                 gridName,
                 gridDataUrl, 
-                editClassificationSystemsUrl);
+                editClassificationSystemsUrl,
+                editStylesheetUrl);
             return RazorView<Detail, DetailViewData>(viewData);
         }
 
@@ -168,6 +170,39 @@ namespace ProjectFirma.Web.Controllers
             var taxonomyLevels = TaxonomyLevel.All.ToSelectListWithEmptyFirstRow(x => x.TaxonomyLevelID.ToString(CultureInfo.InvariantCulture), x => x.TaxonomyLevelDisplayName);
             var viewData = new EditBasicsViewData(CurrentPerson, tenantPeople, taxonomyLevels);
             return RazorPartialView<EditBasics, EditBasicsViewData, EditBasicsViewModel>(viewData, viewModel);
+        }
+
+
+        [HttpGet]
+        [SitkaAdminFeature]
+        public PartialViewResult EditStylesheet()
+        {
+            var tenant = HttpRequestStorage.Tenant;
+            var viewModel = new EditStylesheetViewModel(tenant);
+            return ViewEditStylesheet(viewModel);
+        }
+
+        [HttpPost]
+        [SitkaAdminFeature]
+        [AutomaticallyCallEntityFrameworkSaveChangesWhenModelValid]
+        public ActionResult EditStylesheet(EditStylesheetViewModel viewModel)
+        {
+            if (!ModelState.IsValid)
+            {
+                return ViewEditStylesheet(viewModel);
+            }
+
+            var tenantAttribute = HttpRequestStorage.DatabaseEntities.AllTenantAttributes.Single(a => a.TenantID == viewModel.TenantID);
+           
+            viewModel.UpdateModel(tenantAttribute, CurrentPerson);
+            
+            return new ModalDialogFormJsonResult(new SitkaRoute<TenantController>(c => c.Detail()).BuildUrlFromExpression());
+        }
+
+        private PartialViewResult ViewEditStylesheet(EditStylesheetViewModel viewModel)
+        {
+            var viewData = new EditStylesheetViewData(CurrentPerson);
+            return RazorPartialView<EditStylesheet, EditStylesheetViewData, EditStylesheetViewModel>(viewData, viewModel);
         }
 
         [HttpGet]

--- a/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
+++ b/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
@@ -630,6 +630,9 @@
     <Compile Include="Views\TaxonomyTierPerformanceMeasure\Edit.cs" />
     <Compile Include="Views\TaxonomyTierPerformanceMeasure\EditViewData.cs" />
     <Compile Include="Views\TaxonomyTierPerformanceMeasure\EditViewModel.cs" />
+    <Compile Include="Views\Tenant\EditTenantLogo.cs" />
+    <Compile Include="Views\Tenant\EditTenantLogoViewData.cs" />
+    <Compile Include="Views\Tenant\EditTenantLogoViewModel.cs" />
     <Compile Include="Views\Tenant\EditStylesheet.cs" />
     <Compile Include="Views\Tenant\EditStylesheetViewData.cs" />
     <Compile Include="Views\Tenant\EditStylesheetViewModel.cs" />
@@ -1633,6 +1636,7 @@
     <Content Include="Views\Shared\EditorTemplates\ProjectCustomAttributes.cshtml" />
     <Content Include="Views\ProjectUpdate\EditProjectUpdateConfiguration.cshtml" />
     <Content Include="Views\Tenant\EditStylesheet.cshtml" />
+    <Content Include="Views\Tenant\EditTenantLogo.cshtml" />
     <Reference Include="Antlr3.Runtime">
       <HintPath>..\NuGetPackages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>

--- a/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
+++ b/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
@@ -630,6 +630,9 @@
     <Compile Include="Views\TaxonomyTierPerformanceMeasure\Edit.cs" />
     <Compile Include="Views\TaxonomyTierPerformanceMeasure\EditViewData.cs" />
     <Compile Include="Views\TaxonomyTierPerformanceMeasure\EditViewModel.cs" />
+    <Compile Include="Views\Tenant\EditStylesheet.cs" />
+    <Compile Include="Views\Tenant\EditStylesheetViewData.cs" />
+    <Compile Include="Views\Tenant\EditStylesheetViewModel.cs" />
     <Compile Include="Views\Tenant\EditClassificationSystems.cs" />
     <Compile Include="Views\Tenant\EditClassificationSystemsViewData.cs" />
     <Compile Include="Models\ClassificationSystemSimple.cs" />
@@ -1629,6 +1632,7 @@
     <Content Include="Views\ProjectCustomAttributeType\Manage.cshtml" />
     <Content Include="Views\Shared\EditorTemplates\ProjectCustomAttributes.cshtml" />
     <Content Include="Views\ProjectUpdate\EditProjectUpdateConfiguration.cshtml" />
+    <Content Include="Views\Tenant\EditStylesheet.cshtml" />
     <Reference Include="Antlr3.Runtime">
       <HintPath>..\NuGetPackages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>

--- a/Source/ProjectFirma.Web/Views/Tenant/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Tenant/Detail.cshtml
@@ -77,7 +77,7 @@
                             <li>@ViewDataTyped.Tenant.CanonicalHostNameLocal</li>
                             <li>@ViewDataTyped.Tenant.CanonicalHostNameQa</li>
                             <li>@ViewDataTyped.Tenant.CanonicalHostNameProd</li>
-                        </ul>                        
+                        </ul>
                     </div>
                 </div>
                 <div class="row">
@@ -144,7 +144,7 @@
                         @ViewDataTyped.TenantAttribute.ProjectExternalDataSourceEnabled.ToYesNo()
                     </div>
                 </div>
-                <div class="row">
+                @*<div class="row">
                     <div class="col-sm-5 fieldLabel text-right">
                         @if (ViewDataTyped.IsCurrentTenant && ViewDataTyped.TenantAttribute.TenantStyleSheetFileResource != null)
                         {
@@ -164,8 +164,8 @@
                             <em>No custom style sheet provided</em>
                         }
                     </div>
-                </div>
-                <div class="row">
+                </div>*@
+                @*<div class="row">
                     <div class="col-sm-5 fieldLabel text-right">
                         @if (ViewDataTyped.IsCurrentTenant && ViewDataTyped.TenantAttribute.TenantSquareLogoFileResource != null)
                         {
@@ -206,7 +206,7 @@
                             <em>Tenant Banner Logo is set to the default.</em>
                         }
                     </div>
-                </div>
+                </div>*@
                 <div class="row">
                     <div class="col-sm-5 fieldLabel text-right">
                         @Html.LabelWithSugarFor(FieldDefinition.ShowLeadImplementerLogoOnFactSheet)
@@ -282,6 +282,109 @@
             </div>
             <div class="panel-body">
                 @Html.DhtmlxGrid(ViewDataTyped.GridSpec, ViewDataTyped.GridName, ViewDataTyped.GridDataUrl, null, DhtmlxGridResizeType.VerticalFillHorizontalAutoFit)
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="panel panelFirma">
+            <div class="panel-heading panelTitle">
+                Logos
+            </div>
+            <div class="row panel-body">
+                <div class="col-sm-2 fieldLabel text-right">
+                    @if (ViewDataTyped.IsCurrentTenant && ViewDataTyped.TenantAttribute.TenantSquareLogoFileResource != null)
+                    {
+                        @ModalDialogFormHelper.MakeDeleteLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-trash").ToString(), ViewDataTyped.DeleteTenantSquareLogoFileResourceUrl, null, ViewDataTyped.UserHasTenantManagePermissions)
+                    }
+                    Square Logo
+                </div>
+                <div class="col-sm-7">
+                    @if (ViewDataTyped.TenantAttribute.TenantSquareLogoFileResource != null)
+                    {
+                        <div style="margin-bottom: 15px;">
+                            @Html.Image(ViewDataTyped.TenantAttribute.TenantSquareLogoFileResource.FileResourceUrl, new { style = "max-width: 100%;" })
+                        </div>
+                    }
+                    else
+                    {
+                        <em>Square Logo is set to the default.</em>
+                    }
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-sm-2 fieldLabel text-right">
+                    @if (ViewDataTyped.IsCurrentTenant && ViewDataTyped.TenantAttribute.TenantBannerLogoFileResource != null)
+                    {
+                        @ModalDialogFormHelper.MakeDeleteLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-trash").ToString(), ViewDataTyped.DeleteTenantBannerLogoFileResourceUrl, null, ViewDataTyped.UserHasTenantManagePermissions)
+                    }
+                    Tenant Banner Logo
+                </div>
+                <div class="col-sm-7">
+                    @if (ViewDataTyped.TenantAttribute.TenantBannerLogoFileResource != null)
+                    {
+                        <div style="margin-bottom: 15px;">
+                            @Html.Image(ViewDataTyped.TenantAttribute.TenantBannerLogoFileResource.FileResourceUrl, new { style = "max-width: 100%;" })
+                        </div>
+                    }
+                    else
+                    {
+                        <em>Tenant Banner Logo is set to the default.</em>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="panel panelFirma">
+            <div class="panel-heading panelTitle">
+                @if (ViewDataTyped.IsCurrentTenant)
+                {
+                    @ModalDialogFormHelper.ModalDialogFormLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-edit").ToString(), ViewDataTyped.EditStylesheetUrl, string.Format("Edit Tenant: {0}", ViewDataTyped.TenantAttribute.TenantDisplayName), 800, "Save", "Cancel", new List<string>(), null, null)
+                }
+                Tenant Style Sheet
+            </div>
+            <div class="panel-body">
+                <div class="row">
+                    <div class="col-sm-2 fieldLabel text-right">
+                        @if (ViewDataTyped.IsCurrentTenant && ViewDataTyped.TenantAttribute.TenantStyleSheetFileResource != null)
+                        {
+                            @ModalDialogFormHelper.MakeDeleteLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-trash").ToString(), ViewDataTyped.DeleteTenantStyleSheetFileResourceUrl, null, ViewDataTyped.UserHasTenantManagePermissions)
+                        }
+                    </div>
+                    <div class="col-sm-7">
+                        @if (ViewDataTyped.TenantAttribute.TenantStyleSheetFileResource != null)
+                        {
+                            <a href="@ViewDataTyped.TenantAttribute.TenantStyleSheetFileResource.FileResourceUrl" target="_blank">
+                                @ViewDataTyped.TenantAttribute.TenantStyleSheetFileResource.OriginalCompleteFileName
+                            </a>
+                        }
+                        else
+                        {
+                            <em>No custom style sheet provided</em>
+                        }
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/Source/ProjectFirma.Web/Views/Tenant/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Tenant/Detail.cshtml
@@ -303,6 +303,10 @@
     <div class="col-md-12">
         <div class="panel panelFirma">
             <div class="panel-heading panelTitle">
+                @if (ViewDataTyped.IsCurrentTenant)
+                {
+                    @ModalDialogFormHelper.ModalDialogFormLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-edit").ToString(), ViewDataTyped.EditTenantLogoUrl, string.Format("Edit Tenant: {0}", ViewDataTyped.TenantAttribute.TenantDisplayName), 800, "Save", "Cancel", new List<string>(), null, null)
+                }
                 Logos
             </div>
             <div class="row panel-body">

--- a/Source/ProjectFirma.Web/Views/Tenant/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Tenant/Detail.cshtml
@@ -144,69 +144,6 @@
                         @ViewDataTyped.TenantAttribute.ProjectExternalDataSourceEnabled.ToYesNo()
                     </div>
                 </div>
-                @*<div class="row">
-                    <div class="col-sm-5 fieldLabel text-right">
-                        @if (ViewDataTyped.IsCurrentTenant && ViewDataTyped.TenantAttribute.TenantStyleSheetFileResource != null)
-                        {
-                            @ModalDialogFormHelper.MakeDeleteLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-trash").ToString(), ViewDataTyped.DeleteTenantStyleSheetFileResourceUrl, null, ViewDataTyped.UserHasTenantManagePermissions)
-                        }
-                        Tenant Style Sheet
-                    </div>
-                    <div class="col-sm-7">
-                        @if (ViewDataTyped.TenantAttribute.TenantStyleSheetFileResource != null)
-                        {
-                            <a href="@ViewDataTyped.TenantAttribute.TenantStyleSheetFileResource.FileResourceUrl" target="_blank">
-                                @ViewDataTyped.TenantAttribute.TenantStyleSheetFileResource.OriginalCompleteFileName
-                            </a>
-                        }
-                        else
-                        {
-                            <em>No custom style sheet provided</em>
-                        }
-                    </div>
-                </div>*@
-                @*<div class="row">
-                    <div class="col-sm-5 fieldLabel text-right">
-                        @if (ViewDataTyped.IsCurrentTenant && ViewDataTyped.TenantAttribute.TenantSquareLogoFileResource != null)
-                        {
-                            @ModalDialogFormHelper.MakeDeleteLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-trash").ToString(), ViewDataTyped.DeleteTenantSquareLogoFileResourceUrl, null, ViewDataTyped.UserHasTenantManagePermissions)
-                        }
-                        Square Logo
-                    </div>
-                    <div class="col-sm-7">
-                        @if (ViewDataTyped.TenantAttribute.TenantSquareLogoFileResource != null)
-                        {
-                            <div style="margin-bottom: 15px;">
-                                @Html.Image(ViewDataTyped.TenantAttribute.TenantSquareLogoFileResource.FileResourceUrl, new { style = "max-width: 100%;" })
-                            </div>
-                        }
-                        else
-                        {
-                            <em>Square Logo is set to the default.</em>
-                        }
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-sm-5 fieldLabel text-right">
-                        @if (ViewDataTyped.IsCurrentTenant && ViewDataTyped.TenantAttribute.TenantBannerLogoFileResource != null)
-                        {
-                            @ModalDialogFormHelper.MakeDeleteLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-trash").ToString(), ViewDataTyped.DeleteTenantBannerLogoFileResourceUrl, null, ViewDataTyped.UserHasTenantManagePermissions)
-                        }
-                        Tenant Banner Logo
-                    </div>
-                    <div class="col-sm-7">
-                        @if (ViewDataTyped.TenantAttribute.TenantBannerLogoFileResource != null)
-                        {
-                            <div style="margin-bottom: 15px;">
-                                @Html.Image(ViewDataTyped.TenantAttribute.TenantBannerLogoFileResource.FileResourceUrl, new { style = "max-width: 100%;" })
-                            </div>
-                        }
-                        else
-                        {
-                            <em>Tenant Banner Logo is set to the default.</em>
-                        }
-                    </div>
-                </div>*@
                 <div class="row">
                     <div class="col-sm-5 fieldLabel text-right">
                         @Html.LabelWithSugarFor(FieldDefinition.ShowLeadImplementerLogoOnFactSheet)
@@ -274,18 +211,7 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <div class="col-md-12">
-        <div class="panel panelFirma">
-            <div class="panel-heading panelTitle">
-                All Tenants
-            </div>
-            <div class="panel-body">
-                @Html.DhtmlxGrid(ViewDataTyped.GridSpec, ViewDataTyped.GridName, ViewDataTyped.GridDataUrl, null, DhtmlxGridResizeType.VerticalFillHorizontalAutoFit)
-            </div>
-        </div>
-    </div>
-</div>
+
 
 
 
@@ -389,6 +315,20 @@
                         }
                     </div>
                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="panel panelFirma">
+            <div class="panel-heading panelTitle">
+                All Tenants
+            </div>
+            <div class="panel-body">
+                @Html.DhtmlxGrid(ViewDataTyped.GridSpec, ViewDataTyped.GridName, ViewDataTyped.GridDataUrl, null, DhtmlxGridResizeType.VerticalFillHorizontalAutoFit)
             </div>
         </div>
     </div>

--- a/Source/ProjectFirma.Web/Views/Tenant/DetailViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/DetailViewData.cs
@@ -33,6 +33,7 @@ namespace ProjectFirma.Web.Views.Tenant
         public readonly string EditBasicsUrl;
         public readonly string EditBoundingBoxUrl;
         public readonly string EditClassificationSystemsUrl;
+        public readonly string EditStylesheetUrl;
         public readonly bool UserHasTenantManagePermissions;
         public readonly SitkaRoute<UserController> PrimaryContactRoute;
         public readonly string DeleteTenantStyleSheetFileResourceUrl;
@@ -49,7 +50,7 @@ namespace ProjectFirma.Web.Views.Tenant
             string editBasicsUrl, string editBoundingBoxUrl, string deleteTenantStyleSheetFileResourceUrl,
             string deleteTenantSquareLogoFileResourceUrl, string deleteTenantBannerLogoFileResourceUrl,
             string editBoundingBoxFormID, MapInitJson mapInitJson, DetailGridSpec gridSpec, string gridName,
-            string gridDataUrl, string editClassificationSystemsUrl)
+            string gridDataUrl, string editClassificationSystemsUrl, string editStylesheetUrl)
             : base(currentPerson)
         {
             PageTitle = tenantAttribute.TenantDisplayName;
@@ -58,6 +59,7 @@ namespace ProjectFirma.Web.Views.Tenant
             EditBasicsUrl = editBasicsUrl;
             EditBoundingBoxUrl = editBoundingBoxUrl;
             EditClassificationSystemsUrl = editClassificationSystemsUrl;
+            EditStylesheetUrl = editStylesheetUrl;
             PrimaryContactRoute = tenantAttribute.PrimaryContactPerson != null ? new SitkaRoute<UserController>(c => c.Detail(tenantAttribute.PrimaryContactPersonID)) : null;
             UserHasTenantManagePermissions = new SitkaAdminFeature().HasPermissionByPerson(CurrentPerson);
             DeleteTenantStyleSheetFileResourceUrl = deleteTenantStyleSheetFileResourceUrl;

--- a/Source/ProjectFirma.Web/Views/Tenant/DetailViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/DetailViewData.cs
@@ -34,6 +34,7 @@ namespace ProjectFirma.Web.Views.Tenant
         public readonly string EditBoundingBoxUrl;
         public readonly string EditClassificationSystemsUrl;
         public readonly string EditStylesheetUrl;
+        public readonly string EditTenantLogoUrl;
         public readonly bool UserHasTenantManagePermissions;
         public readonly SitkaRoute<UserController> PrimaryContactRoute;
         public readonly string DeleteTenantStyleSheetFileResourceUrl;
@@ -50,7 +51,7 @@ namespace ProjectFirma.Web.Views.Tenant
             string editBasicsUrl, string editBoundingBoxUrl, string deleteTenantStyleSheetFileResourceUrl,
             string deleteTenantSquareLogoFileResourceUrl, string deleteTenantBannerLogoFileResourceUrl,
             string editBoundingBoxFormID, MapInitJson mapInitJson, DetailGridSpec gridSpec, string gridName,
-            string gridDataUrl, string editClassificationSystemsUrl, string editStylesheetUrl)
+            string gridDataUrl, string editClassificationSystemsUrl, string editStylesheetUrl, string editTenantLogoUrl)
             : base(currentPerson)
         {
             PageTitle = tenantAttribute.TenantDisplayName;
@@ -60,6 +61,7 @@ namespace ProjectFirma.Web.Views.Tenant
             EditBoundingBoxUrl = editBoundingBoxUrl;
             EditClassificationSystemsUrl = editClassificationSystemsUrl;
             EditStylesheetUrl = editStylesheetUrl;
+            EditTenantLogoUrl = editTenantLogoUrl;
             PrimaryContactRoute = tenantAttribute.PrimaryContactPerson != null ? new SitkaRoute<UserController>(c => c.Detail(tenantAttribute.PrimaryContactPersonID)) : null;
             UserHasTenantManagePermissions = new SitkaAdminFeature().HasPermissionByPerson(CurrentPerson);
             DeleteTenantStyleSheetFileResourceUrl = deleteTenantStyleSheetFileResourceUrl;

--- a/Source/ProjectFirma.Web/Views/Tenant/EditBasics.cshtml
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditBasics.cshtml
@@ -30,14 +30,14 @@ Source code is available upon request via <support@sitkatech.com>.
     <div class="form-group">
         <div class="col-md-4 text-right">@Html.LabelFor(m => m.TenantDisplayName)</div>
         <div class="col-md-8">
-            @Html.TextBoxFor(m => m.TenantDisplayName, new {@class = "form-control", style = "width:auto;"})
+            @Html.TextBoxFor(m => m.TenantDisplayName, new {@class = "form-control"})
             @Html.ValidationMessageFor(x => x.TenantDisplayName)
         </div>
     </div>
     <div class="form-group">
         <div class="col-md-4 text-right">@Html.LabelFor(m => m.ToolDisplayName)</div>
         <div class="col-md-8">
-            @Html.TextBoxFor(m => m.ToolDisplayName, new {@class = "form-control", style = "width:auto;"})
+            @Html.TextBoxFor(m => m.ToolDisplayName, new {@class = "form-control"})
             @Html.ValidationMessageFor(x => x.ToolDisplayName)
         </div>
     </div>
@@ -65,7 +65,7 @@ Source code is available upon request via <support@sitkatech.com>.
                 </div>
             </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-4" style="margin: 20px 0;">
             <span class="smallExplanationText">Changing the number of Taxonomy Tiers or which Taxonomy Tier to associate Performance Measures to will result in the deletion of any relationships to Performance Measures</span>
         </div>
     </div>
@@ -79,7 +79,12 @@ Source code is available upon request via <support@sitkatech.com>.
     <div class="form-group">
         <div class="col-md-4 text-right">@Html.LabelWithSugarFor(m => m.ShowProposalsToThePublic)</div>
         <div class="col-md-8">
-            @Html.CheckBoxFor(m => m.ShowProposalsToThePublic)
+            <label class="radio-inline">
+                @Html.RadioButtonFor(m => m.ShowProposalsToThePublic, true) Yes
+            </label>
+            <label class="radio-inline">
+                @Html.RadioButtonFor(m => m.ShowProposalsToThePublic, false) No
+            </label>
         </div>
     </div>
     <div class="form-group">

--- a/Source/ProjectFirma.Web/Views/Tenant/EditBasics.cshtml
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditBasics.cshtml
@@ -83,20 +83,6 @@ Source code is available upon request via <support@sitkatech.com>.
         </div>
     </div>
     <div class="form-group">
-        <div class="col-md-4 text-right">@Html.LabelFor(m => m.MapServiceUrl)</div>
-        <div class="col-md-8">
-            @Html.TextBoxFor(m => m.MapServiceUrl, new {@class = "form-control"})
-            @Html.ValidationMessageFor(m => m.MapServiceUrl)
-        </div>
-    </div>
-    <div class="form-group">
-        <div class="col-md-4 text-right">@Html.LabelFor(m => m.WatershedLayerName)</div>
-        <div class="col-md-8">
-            @Html.TextBoxFor(m => m.WatershedLayerName, new {@class = "form-control", style = "width: auto;"})
-            @Html.ValidationMessageFor(m => m.WatershedLayerName)
-        </div>
-    </div>
-    <div class="form-group">
         <div class="col-md-4 text-right">@Html.LabelFor(m => m.ProjectExternalDataSourceEnabled)</div>
         <div class="col-md-8">
             <div>
@@ -111,36 +97,6 @@ Source code is available upon request via <support@sitkatech.com>.
         </div>
     </div>
     <div class="form-group">
-        <div class="col-md-4 text-right">@Html.LabelFor(m => m.TenantStyleSheetFileResourceData)</div>
-        <div class="col-md-8">
-            @Html.EditorFor(x => x.TenantStyleSheetFileResourceData)
-            <span class="smallExplanationText">
-                Allowed Extensions: @Model.GetFileExtensions(x => x.TenantStyleSheetFileResourceData)
-            </span>
-            @Html.ValidationMessageFor(x => x.TenantStyleSheetFileResourceData)
-        </div>
-    </div>
-    <div class="form-group">
-        <div class="col-md-4 text-right">@Html.LabelFor(m => m.TenantSquareLogoFileResourceData)</div>
-        <div class="col-md-8">
-            @Html.EditorFor(x => x.TenantSquareLogoFileResourceData)
-            <span class="smallExplanationText">
-                Allowed Extensions: @Model.GetFileExtensions(x => x.TenantSquareLogoFileResourceData)
-            </span>
-            @Html.ValidationMessageFor(x => x.TenantSquareLogoFileResourceData)
-        </div>
-    </div>
-    <div class="form-group">
-        <div class="col-md-4 text-right">@Html.LabelFor(m => m.TenantBannerLogoFileResourceData)</div>
-        <div class="col-md-8">
-            @Html.EditorFor(x => x.TenantBannerLogoFileResourceData)
-            <span class="smallExplanationText">
-                Allowed Extensions: @Model.GetFileExtensions(x => x.TenantBannerLogoFileResourceData)
-            </span>
-            @Html.ValidationMessageFor(x => x.TenantBannerLogoFileResourceData)
-        </div>
-    </div>
-    <div class="form-group">
         <div class="col-md-4 text-right">@Html.LabelWithSugarFor(m => m.ShowLeadImplementerLogoOnFactSheet)</div>
         <div class="col-md-8">
             @Html.CheckBoxFor(x => x.ShowLeadImplementerLogoOnFactSheet)
@@ -152,6 +108,21 @@ Source code is available upon request via <support@sitkatech.com>.
         <div class="col-md-8">
             @Html.CheckBoxFor(x => x.EnableAccomplishmentsDashboard)
             @Html.ValidationMessageFor(x => x.ShowLeadImplementerLogoOnFactSheet)
+        </div>
+    </div>
+    <hr/>
+    <div class="form-group">
+        <div class="col-md-4 text-right">@Html.LabelFor(m => m.MapServiceUrl)</div>
+        <div class="col-md-8">
+            @Html.TextBoxFor(m => m.MapServiceUrl, new {@class = "form-control"})
+            @Html.ValidationMessageFor(m => m.MapServiceUrl)
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-4 text-right">@Html.LabelFor(m => m.WatershedLayerName)</div>
+        <div class="col-md-8">
+            @Html.TextBoxFor(m => m.WatershedLayerName, new {@class = "form-control", style = "width: auto;"})
+            @Html.ValidationMessageFor(m => m.WatershedLayerName)
         </div>
     </div>
 </div>

--- a/Source/ProjectFirma.Web/Views/Tenant/EditBasicsViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditBasicsViewModel.cs
@@ -82,7 +82,8 @@ namespace ProjectFirma.Web.Views.Tenant
         public bool? ProjectExternalDataSourceEnabled { get; set; }
 
         [FieldDefinitionDisplay(FieldDefinitionEnum.ShowProposalsToThePublic)]
-        public bool ShowProposalsToThePublic { get; set; }
+        [Required]
+        public bool? ShowProposalsToThePublic { get; set; }
 
         [FieldDefinitionDisplay(FieldDefinitionEnum.ShowLeadImplementerLogoOnFactSheet)]
         public bool ShowLeadImplementerLogoOnFactSheet { get; set; }
@@ -118,7 +119,7 @@ namespace ProjectFirma.Web.Views.Tenant
         {
             attribute.TenantDisplayName = TenantDisplayName;
             attribute.ToolDisplayName = ToolDisplayName;
-            attribute.ShowProposalsToThePublic = ShowProposalsToThePublic;
+            attribute.ShowProposalsToThePublic = ShowProposalsToThePublic.GetValueOrDefault();
             attribute.ShowLeadImplementerLogoOnFactSheet = ShowLeadImplementerLogoOnFactSheet;
             attribute.EnableAccomplishmentsDashboard = EnableAccomplishmentsDashboard;
 

--- a/Source/ProjectFirma.Web/Views/Tenant/EditStylesheet.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditStylesheet.cs
@@ -1,0 +1,28 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="EditBasics.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+using LtInfo.Common.Mvc;
+
+namespace ProjectFirma.Web.Views.Tenant
+{
+    public abstract class EditStylesheet : TypedWebPartialViewPage<EditStylesheetViewData, EditStylesheetViewModel>
+    {
+    }
+}

--- a/Source/ProjectFirma.Web/Views/Tenant/EditStylesheet.cshtml
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditStylesheet.cshtml
@@ -1,0 +1,42 @@
+﻿@*-----------------------------------------------------------------------
+<copyright file="EditBasics.cshtml" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*@
+@using LtInfo.Common.HtmlHelperExtensions
+@using LtInfo.Common.Mvc
+@using ProjectFirma.Web.Views.Tenant
+@inherits EditStylesheet
+
+@using (Html.BeginForm())
+{
+<div class="form-horizontal">
+    @Html.HiddenFor(m => m.TenantID)
+   
+    <div class="form-group">
+        <div class="col-md-4 text-right">@Html.LabelWithSugarFor(m => m.TenantStyleSheetFileResourceData)</div>
+        <div class="col-md-8">
+            @Html.EditorFor(x => x.TenantStyleSheetFileResourceData)
+            <span class="smallExplanationText">
+                Allowed Extensions: @Model.GetFileExtensions(x => x.TenantStyleSheetFileResourceData)
+            </span>
+            @Html.ValidationMessageFor(x => x.TenantStyleSheetFileResourceData)
+        </div>
+    </div>
+</div>
+}

--- a/Source/ProjectFirma.Web/Views/Tenant/EditStylesheetViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditStylesheetViewData.cs
@@ -1,0 +1,36 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="EditBasicsViewData.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+using System.Collections.Generic;
+using System.Web.Mvc;
+using ProjectFirma.Web.Models;
+
+namespace ProjectFirma.Web.Views.Tenant
+{
+    public class EditStylesheetViewData : FirmaViewData
+    {
+        
+        public EditStylesheetViewData(Person currentPerson)
+            : base(currentPerson)
+        {
+
+        }
+    }
+}

--- a/Source/ProjectFirma.Web/Views/Tenant/EditStylesheetViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditStylesheetViewModel.cs
@@ -1,0 +1,72 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="EditBasicsViewModel.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Web;
+using LtInfo.Common;
+using LtInfo.Common.Models;
+using LtInfo.Common.Mvc;
+using ProjectFirma.Web.Common;
+using ProjectFirma.Web.Models;
+using ProjectFirma.Web.Security;
+
+namespace ProjectFirma.Web.Views.Tenant
+{
+    public class EditStylesheetViewModel : FormViewModel, IValidatableObject
+    {
+        [Required]
+        public int? TenantID { get; set; }
+
+        
+        [DisplayName("Tenant Style Sheet")]
+        [SitkaFileExtensions("css")]
+        [Required]
+        public HttpPostedFileBase TenantStyleSheetFileResourceData { get; set; }
+
+       
+
+        /// <summary>
+        /// Needed by ModelBinder
+        /// </summary>
+        public EditStylesheetViewModel()
+        {
+        }
+
+        public EditStylesheetViewModel(Models.Tenant tenant)
+        {
+            TenantID = tenant.TenantID; 
+        }
+
+        public void UpdateModel(TenantAttribute attribute, Person currentPerson)
+        {
+           attribute.TenantStyleSheetFileResource?.DeleteFileResource();
+           attribute.TenantStyleSheetFileResource = FileResource.CreateNewFromHttpPostedFileAndSave(TenantStyleSheetFileResourceData, currentPerson);
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            var errors = new List<ValidationResult>();
+
+            return errors;
+        }
+    }
+}

--- a/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogo.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogo.cs
@@ -1,0 +1,28 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="EditBasics.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+using LtInfo.Common.Mvc;
+
+namespace ProjectFirma.Web.Views.Tenant
+{
+    public abstract class EditTenantLogo : TypedWebPartialViewPage<EditTenantLogoViewData, EditTenantLogoViewModel>
+    {
+    }
+}

--- a/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogo.cshtml
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogo.cshtml
@@ -1,0 +1,54 @@
+﻿@*-----------------------------------------------------------------------
+<copyright file="EditBasics.cshtml" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*@
+@using LtInfo.Common.HtmlHelperExtensions
+@using LtInfo.Common.Mvc
+@using ProjectFirma.Web.Views.Tenant
+@inherits EditTenantLogo
+
+@using (Html.BeginForm())
+{
+<div class="form-horizontal">
+    @Html.HiddenFor(m => m.TenantID)
+   
+
+    <div class="form-group">
+        <div class="col-md-4 text-right">@Html.LabelFor(m => m.TenantSquareLogoFileResourceData)</div>
+        <div class="col-md-8">
+            @Html.EditorFor(x => x.TenantSquareLogoFileResourceData)
+            <span class="smallExplanationText">
+                Allowed Extensions: @Model.GetFileExtensions(x => x.TenantSquareLogoFileResourceData)
+            </span>
+            @Html.ValidationMessageFor(x => x.TenantSquareLogoFileResourceData)
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-4 text-right">@Html.LabelFor(m => m.TenantBannerLogoFileResourceData)</div>
+        <div class="col-md-8">
+            @Html.EditorFor(x => x.TenantBannerLogoFileResourceData)
+            <span class="smallExplanationText">
+                Allowed Extensions: @Model.GetFileExtensions(x => x.TenantBannerLogoFileResourceData)
+            </span>
+            @Html.ValidationMessageFor(x => x.TenantBannerLogoFileResourceData)
+        </div>
+    </div>
+
+</div>
+}

--- a/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogoViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogoViewData.cs
@@ -1,0 +1,36 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="EditBasicsViewData.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+using System.Collections.Generic;
+using System.Web.Mvc;
+using ProjectFirma.Web.Models;
+
+namespace ProjectFirma.Web.Views.Tenant
+{
+    public class EditTenantLogoViewData : FirmaViewData
+    {
+
+        public EditTenantLogoViewData(Person currentPerson)
+            : base(currentPerson)
+        {
+
+        }
+    }
+}

--- a/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogoViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogoViewModel.cs
@@ -1,0 +1,84 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="EditBasicsViewModel.cs" company="Tahoe Regional Planning Agency and Sitka Technology Group">
+Copyright (c) Tahoe Regional Planning Agency and Sitka Technology Group. All rights reserved.
+<author>Sitka Technology Group</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Web;
+using LtInfo.Common;
+using LtInfo.Common.Models;
+using LtInfo.Common.Mvc;
+using ProjectFirma.Web.Common;
+using ProjectFirma.Web.Models;
+using ProjectFirma.Web.Security;
+
+namespace ProjectFirma.Web.Views.Tenant
+{
+    public class EditTenantLogoViewModel : FormViewModel, IValidatableObject
+    {
+        [Required]
+        public int? TenantID { get; set; }
+
+       
+
+        [DisplayName("Tenant Banner Logo")]
+        [SitkaFileExtensions("jpg|jpeg|gif|png")]
+        public HttpPostedFileBase TenantBannerLogoFileResourceData { get; set; }
+
+        [DisplayName("Square Logo")]
+        [SitkaFileExtensions("jpg|jpeg|gif|png")]
+        public HttpPostedFileBase TenantSquareLogoFileResourceData { get; set; }
+
+
+        /// <summary>
+        /// Needed by ModelBinder
+        /// </summary>
+        public EditTenantLogoViewModel()
+        {
+        }
+
+        public EditTenantLogoViewModel(Models.Tenant tenant)
+        {
+            TenantID = tenant.TenantID;
+        }
+
+        public void UpdateModel(TenantAttribute attribute, Person currentPerson)
+        {
+           
+            if (TenantSquareLogoFileResourceData != null)
+            {
+                attribute.TenantSquareLogoFileResource?.DeleteFileResource();
+                attribute.TenantSquareLogoFileResource = FileResource.CreateNewFromHttpPostedFileAndSave(TenantSquareLogoFileResourceData, currentPerson);
+            }
+            if (TenantBannerLogoFileResourceData != null)
+            {
+                attribute.TenantBannerLogoFileResource?.DeleteFileResource();
+                attribute.TenantBannerLogoFileResource = FileResource.CreateNewFromHttpPostedFileAndSave(TenantBannerLogoFileResourceData, currentPerson);
+            }
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            var errors = new List<ValidationResult>();
+
+            return errors;
+        }
+    }
+}


### PR DESCRIPTION
[projectfirma/#1313] Clean up Tenant Configuration editor

* Move stylesheet input to its own panel and, when editing, the inputbox appears in its own modal.
* Moved Tenant Logo input display to its own panel and moved its input to its own modal
* Remove stylesheet and logo input from Basics modal
* Moved Map Service Url and Watershed Layer Name to the bottom of the list of configurable items
* Moved All Tenants to be the last panel on the page
* Increase "Tenant Display Name" input and "Tool Display Name" input to take up the entire space
* Align "Number Of Taxonomy Tiers To Use" with description
* Turn "Show Proposals To The Public" checkbox to radio buttons