### PR TITLE
Features/1331 make add proposal button consistent

### DIFF
--- a/Database/ReleaseScript/174 - Update Funding Type labels for ISWCC Project Tracker.sql
+++ b/Database/ReleaseScript/174 - Update Funding Type labels for ISWCC Project Tracker.sql
@@ -1,0 +1,5 @@
+update dbo.FundingTypeData SET FundingTypeDisplayName = 'One-time', FundingTypeShortName = 'One-time' 
+WHERE TenantID = 9 AND FundingTypeID = 1;
+
+update dbo.FundingTypeData SET FundingTypeDisplayName = 'Ongoing', FundingTypeShortName = 'Ongoing' 
+WHERE TenantID = 9 AND FundingTypeID = 2;

--- a/Source/ProjectFirma.Web/Views/Project/MyOrganizationsProjects.cshtml
+++ b/Source/ProjectFirma.Web/Views/Project/MyOrganizationsProjects.cshtml
@@ -20,6 +20,7 @@ Source code is available upon request via <support@sitkatech.com>.
 -----------------------------------------------------------------------*@
 @using ProjectFirma.Web.Models
 @using ProjectFirma.Web.Views
+@using ProjectFirma.Web.Views.ProjectCreate
 @using ProjectFirma.Web.Views.Shared
 @using LtInfo.Common.DhtmlWrappers
 @using LtInfo.Common.HtmlHelperExtensions
@@ -49,7 +50,7 @@ Source code is available upon request via <support@sitkatech.com>.
     </div>
     <div class="panel-body">
         <div>
-            <a class='btn btn-sm btn-firma' href="@ViewDataTyped.ProposeNewProjectUrl" title="Submit a project proposal">Propose New Project</a>
+            @ProjectCreateHelper.AddProjectButton()
         </div>
         <div>
             @Html.DhtmlxGrid(ViewDataTyped.ProposalsesGridSpec, ViewDataTyped.ProposalsGridName, ViewDataTyped.ProposalsGridDataUrl, "height: 400px;", DhtmlxGridResizeType.VerticalResizableHorizontalAutoFit)

--- a/Source/ProjectFirma.Web/Views/Project/Proposed.cshtml
+++ b/Source/ProjectFirma.Web/Views/Project/Proposed.cshtml
@@ -19,6 +19,7 @@ Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*@
 @using ProjectFirma.Web.Views
+@using ProjectFirma.Web.Views.ProjectCreate
 @using ProjectFirma.Web.Views.Shared
 @using LtInfo.Common.DhtmlWrappers
 @using ProjectFirma.Web.Models
@@ -37,7 +38,7 @@ Source code is available upon request via <support@sitkatech.com>.
 {
     @if (ViewDataTyped.HasProposeProjectPermissions)
     {
-        <a class='btn btn-sm btn-firma' href="@ViewDataTyped.ProposeNewProjectUrl" title="Submit a project proposal">Propose New @FieldDefinition.Project.GetFieldDefinitionLabel()</a>
+        @ProjectCreateHelper.AddProjectButton()
     }
 }
 

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoric.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoric.cshtml
@@ -50,7 +50,7 @@ Source code is available upon request via <support@sitkatech.com>.
     {
         if (ViewDataTyped.IsNewProjectCreate)
         {
-            <a class="btn btn-xs btn-firma" href="@ViewDataTyped.HistoricProjectBasicsUrl">Enter Existing Project <span class='glyphicon glyphicon-chevron-right'></span></a>
+            <a class="btn btn-xs btn-firma" href="@ViewDataTyped.HistoricProjectBasicsUrl">Begin <span class='glyphicon glyphicon-chevron-right'></span></a>
         }
         else
         {

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposal.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposal.cshtml
@@ -50,7 +50,7 @@ Source code is available upon request via <support@sitkatech.com>.
     {
         if (ViewDataTyped.IsNewProjectCreate)
         {
-            <a class="btn btn-xs btn-firma" href="@ViewDataTyped.ProposalBasicsUrl">Propose New Project <span class='glyphicon glyphicon-chevron-right'></span></a>
+            <a class="btn btn-xs btn-firma" href="@ViewDataTyped.ProposalBasicsUrl">Begin<span class='glyphicon glyphicon-chevron-right'></span></a>
         }
         else
         {

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjects.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjects.cshtml
@@ -18,6 +18,7 @@ GNU Affero General Public License <http://www.gnu.org/licenses/> for more detail
 Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*@
+@using ProjectFirma.Web.Views.ProjectCreate
 @using ProjectFirma.Web.Views.ProjectUpdate
 @using ProjectFirma.Web.Views
 @using ProjectFirma.Web.Views.Shared
@@ -36,7 +37,7 @@ Source code is available upon request via <support@sitkatech.com>.
 
 @section RightOfPageTitle
 {
-    <a class='btn btn-sm btn-firma' href="@ViewDataTyped.ProposeNewProjectUrl" title="Submit a project proposal">Propose New Project</a>
+    @ProjectCreateHelper.AddProjectButton()
 }
 
 <div>


### PR DESCRIPTION
[projectfirma/#1331] Make "Add proposal/project" button consistent
* Update all buttons that say "Propose New Project" to match other "Add Button" text and to bring up the "Add Project" modal
* After clicking on the "Add Project" button and after choosing "Add a proposal for a future project" or "Enter an existing project that is already underway or complete", updated the button that allows the person to make and start the project to "Begin"


[projectfirma/#1321] Update Funding Type labels for ISWCC Project Tracker
* Updated database
