### PR TITLE
Features/1331 make add proposal button consistant update

### DIFF
--- a/Source/ProjectFirma.Web/Views/Project/MyOrganizationsProjects.cshtml
+++ b/Source/ProjectFirma.Web/Views/Project/MyOrganizationsProjects.cshtml
@@ -31,6 +31,11 @@ Source code is available upon request via <support@sitkatech.com>.
     @{ DhtmlxGridIncludes.RenderPartialView(Html); }
 }
 
+@section RightOfPageTitle
+{
+    @ProjectCreateHelper.AddProjectButton()
+}
+
 <div>
     @{ ViewPageContent.RenderPartialView(Html, ViewDataTyped.ViewPageContentViewData); }
 </div>
@@ -49,9 +54,6 @@ Source code is available upon request via <support@sitkatech.com>.
         <h2>@Html.LabelWithSugarFor(FieldDefinition.Proposal, LabelWithSugarForExtensions.DisplayStyle.HelpIconOnly) @FieldDefinition.Proposal.GetFieldDefinitionLabelPluralized()</h2>
     </div>
     <div class="panel-body">
-        <div>
-            @ProjectCreateHelper.AddProjectButton()
-        </div>
         <div>
             @Html.DhtmlxGrid(ViewDataTyped.ProposalsesGridSpec, ViewDataTyped.ProposalsGridName, ViewDataTyped.ProposalsGridDataUrl, "height: 400px;", DhtmlxGridResizeType.VerticalResizableHorizontalAutoFit)
         </div>


### PR DESCRIPTION
[projectfirma/#1331] Make "Add proposal/project" button consistent

* Moved the “Add Project” button out of the Proposals panel and to the top right on the My Organization’s Project page
