### PR TITLE
[projectfirma/#1335] Make funding sources more explicit on Fact Sheets

### DIFF
--- a/Source/ProjectFirma.Web/Models/Project.cs
+++ b/Source/ProjectFirma.Web/Models/Project.cs
@@ -110,6 +110,13 @@ namespace ProjectFirma.Web.Models
             return ProjectFundingSourceRequests.Any() ? ProjectFundingSourceRequests.Sum(x => x.UnsecuredAmount.GetValueOrDefault()) : 0;
         }
 
+        public decimal? GetNoFundingSourceIdentifiedAmount()
+        {
+            decimal? estimatedTotalCost = EstimatedTotalCost == null ? 0 : EstimatedTotalCost;
+            decimal? securedFunding = GetSecuredFunding() == null ? 0 : GetSecuredFunding();
+            return estimatedTotalCost - (securedFunding + GetUnsecuredFunding());
+        }
+
 
         public decimal? TotalExpenditures
         {

--- a/Source/ProjectFirma.Web/Models/Project.cs
+++ b/Source/ProjectFirma.Web/Models/Project.cs
@@ -112,9 +112,10 @@ namespace ProjectFirma.Web.Models
 
         public decimal? GetNoFundingSourceIdentifiedAmount()
         {
-            decimal? estimatedTotalCost = EstimatedTotalCost == null ? 0 : EstimatedTotalCost;
-            decimal? securedFunding = GetSecuredFunding() == null ? 0 : GetSecuredFunding();
-            return estimatedTotalCost - (securedFunding + GetUnsecuredFunding());
+            decimal? securedFunding = GetSecuredFunding() == null ? null : GetSecuredFunding();
+            decimal unsecuredFunding = GetUnsecuredFunding();
+
+            return EstimatedTotalCost - securedFunding + unsecuredFunding;
         }
 
 

--- a/Source/ProjectFirma.Web/Views/Project/BackwardLookingFactSheet.cshtml
+++ b/Source/ProjectFirma.Web/Views/Project/BackwardLookingFactSheet.cshtml
@@ -99,7 +99,7 @@
             @{
                 var stewardingOrganization = ViewDataTyped.Project.GetCanStewardProjectsOrganization();
             }
-            @if(stewardingOrganization != null)
+            @if (stewardingOrganization != null)
             {
                 <div class="row">
                     <div class="col-xs-12 col-sm-4 col-md-3">
@@ -113,7 +113,7 @@
             @{
                 var primaryContactOrganization = ViewDataTyped.Project.GetPrimaryContactOrganization();
             }
-            @if(primaryContactOrganization != null)
+            @if (primaryContactOrganization != null)
             {
                 <div class="row">
                     <div class="col-xs-12 col-sm-4 col-md-3">
@@ -184,6 +184,34 @@
                 </div>
                 <div class="col-xs-12 col-sm-8 col-md-9">
                     @ViewDataTyped.Project.Duration
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    <strong>@FieldDefinition.EstimatedTotalCost.GetFieldDefinitionLabel()</strong>
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    @ViewDataTyped.EstimatedTotalCost
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    <strong>No Funding Source Identified</strong>
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    @ViewDataTyped.NoFundingSourceIdentified
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    <strong> @FieldDefinition.SecuredFunding.GetFieldDefinitionLabel()</strong>
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    @ViewDataTyped.SecuredFunding
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    <strong> @FieldDefinition.UnsecuredFunding.GetFieldDefinitionLabel()</strong>
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    @ViewDataTyped.UnsecuredFunding
                 </div>
             </div>
         </div>

--- a/Source/ProjectFirma.Web/Views/Project/BackwardLookingFactSheetViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/BackwardLookingFactSheetViewData.cs
@@ -18,23 +18,27 @@ GNU Affero General Public License <http://www.gnu.org/licenses/> for more detail
 Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*/
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using ProjectFirma.Web.Controllers;
 using ProjectFirma.Web.Models;
 using ProjectFirma.Web.Views.Map;
 using ProjectFirma.Web.Views.Shared;
 using ProjectFirma.Web.Views.Shared.ProjectLocationControls;
-using LtInfo.Common.Models;
 using ProjectFirma.Web.Common;
 using ProjectFirma.Web.Views.Shared.SortOrder;
+using LtInfo.Common;
+using LtInfo.Common.Views;
+
 
 namespace ProjectFirma.Web.Views.Project
 {
     public class BackwardLookingFactSheetViewData : ProjectViewData
     {
+        public string EstimatedTotalCost { get; }
+        public string NoFundingSourceIdentified { get; }
+        public string SecuredFunding { get; }
+        public string UnsecuredFunding { get; }
         public readonly ImageGalleryViewData ImageGalleryViewData;
         public readonly ProjectLocationSummaryViewData ProjectLocationSummaryViewData;
         public readonly List<IGrouping<Models.PerformanceMeasure, PerformanceMeasureReportedValue>> PerformanceMeasureReportedValues;
@@ -61,6 +65,11 @@ namespace ProjectFirma.Web.Views.Project
         {
             PageTitle = project.DisplayName;
             BreadCrumbTitle = "Fact Sheet";
+
+            EstimatedTotalCost = Project.EstimatedTotalCost.HasValue ? Project.EstimatedTotalCost.ToStringCurrency() : ViewUtilities.Unknown;
+            NoFundingSourceIdentified = project.GetNoFundingSourceIdentifiedAmount() != null ? Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency() : ViewUtilities.Unknown;
+            SecuredFunding = Project.GetSecuredFunding() != null ? Project.GetSecuredFunding().ToStringCurrency() : ViewUtilities.Unknown;
+            UnsecuredFunding = Project.GetUnsecuredFunding().ToStringCurrency();
 
             const bool userCanAddPhotosToThisProject = false;
             var newPhotoForProjectUrl = string.Empty;

--- a/Source/ProjectFirma.Web/Views/Project/BackwardLookingFactSheetViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/BackwardLookingFactSheetViewData.cs
@@ -39,26 +39,26 @@ namespace ProjectFirma.Web.Views.Project
         public string NoFundingSourceIdentified { get; }
         public string SecuredFunding { get; }
         public string UnsecuredFunding { get; }
-        public readonly ImageGalleryViewData ImageGalleryViewData;
-        public readonly ProjectLocationSummaryViewData ProjectLocationSummaryViewData;
-        public readonly List<IGrouping<Models.PerformanceMeasure, PerformanceMeasureReportedValue>> PerformanceMeasureReportedValues;
-        public readonly List<GooglePieChartSlice> ExpenditureGooglePieChartSlices;
-        public readonly string ChartID;
-        public readonly Models.ProjectImage KeyPhoto;
-        public readonly List<IGrouping<ProjectImageTiming, Models.ProjectImage>> ProjectImagesExceptKeyPhotoGroupedByTiming;
-        public readonly int ProjectImagesPerTimingGroup;
-        public readonly List<string> ChartColorRange;
-        public readonly List<Models.Classification> Classifications;
-        public readonly GoogleChartJson GoogleChartJson;
-        public readonly int CalculatedChartHeight;
-        public readonly string FactSheetPdfUrl;
+        public ImageGalleryViewData ImageGalleryViewData { get; }
+        public ProjectLocationSummaryViewData ProjectLocationSummaryViewData { get; }
+        public List<IGrouping<Models.PerformanceMeasure, PerformanceMeasureReportedValue>> PerformanceMeasureReportedValues { get; }
+        public List<GooglePieChartSlice> ExpenditureGooglePieChartSlices { get; }
+        public string ChartID { get; }
+        public Models.ProjectImage KeyPhoto { get; }
+        public List<IGrouping<ProjectImageTiming, Models.ProjectImage>> ProjectImagesExceptKeyPhotoGroupedByTiming { get; }
+        public int ProjectImagesPerTimingGroup { get; }
+        public List<string> ChartColorRange { get; }
+        public List<Models.Classification> Classifications { get; }
+        public GoogleChartJson GoogleChartJson { get; }
+        public int CalculatedChartHeight { get; }
+        public string FactSheetPdfUrl { get; }
 
-        public readonly string TaxonomyColor;
-        public readonly string TaxonomyLeafName;
-        public readonly string TaxonomyBranchName;
+        public string TaxonomyColor { get; }
+        public string TaxonomyLeafName { get; }
+        public string TaxonomyBranchName { get; }
 
-        public readonly string TaxonomyLeafDisplayName;
-        public readonly Person PrimaryContactPerson;
+        public string TaxonomyLeafDisplayName { get; }
+        public Person PrimaryContactPerson { get; }
 
         public BackwardLookingFactSheetViewData(Person currentPerson, Models.Project project, ProjectLocationSummaryMapInitJson projectLocationSummaryMapInitJson, GoogleChartJson projectFactSheetGoogleChart,
             List<GooglePieChartSlice> expenditureGooglePieChartSlices, List<string> chartColorRange) : base(currentPerson, project)
@@ -66,9 +66,9 @@ namespace ProjectFirma.Web.Views.Project
             PageTitle = project.DisplayName;
             BreadCrumbTitle = "Fact Sheet";
 
-            EstimatedTotalCost = Project.EstimatedTotalCost.HasValue ? Project.EstimatedTotalCost.ToStringCurrency() : ViewUtilities.Unknown;
-            NoFundingSourceIdentified = project.GetNoFundingSourceIdentifiedAmount() != null ? Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency() : ViewUtilities.Unknown;
-            SecuredFunding = Project.GetSecuredFunding() != null ? Project.GetSecuredFunding().ToStringCurrency() : ViewUtilities.Unknown;
+            EstimatedTotalCost = Project.EstimatedTotalCost.HasValue ? Project.EstimatedTotalCost.ToStringCurrency() : "";
+            NoFundingSourceIdentified = project.GetNoFundingSourceIdentifiedAmount() != null ? Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency() : "";
+            SecuredFunding = Project.GetSecuredFunding() != null ? Project.GetSecuredFunding().ToStringCurrency() : "";
             UnsecuredFunding = Project.GetUnsecuredFunding().ToStringCurrency();
 
             const bool userCanAddPhotosToThisProject = false;

--- a/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheet.cshtml
+++ b/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheet.cshtml
@@ -194,10 +194,24 @@
                     @ViewDataTyped.EstimatedTotalCost
                 </div>
                 <div class="col-xs-12 col-sm-4 col-md-3">
-                    <strong>Funding Request</strong>
+                    <strong>No Funding Source Identified</strong>
                 </div>
                 <div class="col-xs-12 col-sm-4 col-md-3">
-                    @ViewDataTyped.FundingRequest
+                    @ViewDataTyped.NoFundingSourceIdentified
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    <strong> @FieldDefinition.SecuredFunding.GetFieldDefinitionLabel()</strong>
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    @ViewDataTyped.SecuredFunding
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    <strong> @FieldDefinition.UnsecuredFunding.GetFieldDefinitionLabel()</strong>
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    @ViewDataTyped.UnsecuredFunding
                 </div>
             </div>
         </div>

--- a/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
@@ -47,6 +47,9 @@ namespace ProjectFirma.Web.Views.Project
         public readonly List<Models.Classification> Classifications;
         public readonly GoogleChartJson GoogleChartJson;
         public readonly string EstimatedTotalCost;
+        public string NoFundingSourceIdentified { get; }
+        public string SecuredFunding { get; }
+        public string UnsecuredFunding { get; }
         public readonly string FundingRequest;
         public readonly int CalculatedChartHeight;
         public readonly string FactSheetPdfUrl;
@@ -109,6 +112,11 @@ namespace ProjectFirma.Web.Views.Project
             TaxonomyBranchName = project.TaxonomyLeaf == null ? $"{Models.FieldDefinition.Project.GetFieldDefinitionLabel()} Taxonomy Not Set" : project.TaxonomyLeaf.TaxonomyBranch.DisplayName;
             TaxonomyLeafDisplayName = Models.FieldDefinition.TaxonomyLeaf.GetFieldDefinitionLabel();
             EstimatedTotalCost = Project.EstimatedTotalCost.HasValue ? Project.EstimatedTotalCost.ToStringCurrency() : ViewUtilities.Unknown;
+            NoFundingSourceIdentified = project.GetNoFundingSourceIdentifiedAmount() != null ? Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency() : ViewUtilities.Unknown;
+            SecuredFunding = Project.GetSecuredFunding() != null ? Project.GetSecuredFunding().ToStringCurrency() : ViewUtilities.Unknown;
+            UnsecuredFunding = Project.GetUnsecuredFunding().ToStringCurrency();
+
+
             FundingRequest = project.ProjectFundingSourceRequests.Any() ? project.ProjectFundingSourceRequests.Sum(x => x.UnsecuredAmount).ToStringCurrency() : ViewUtilities.Unknown;
         }
 

--- a/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
@@ -38,26 +38,26 @@ namespace ProjectFirma.Web.Views.Project
 {
     public class ForwardLookingFactSheetViewData : ProjectViewData
     {
-        public readonly ProjectLocationSummaryViewData ProjectLocationSummaryViewData;
-        public readonly List<IGrouping<Models.PerformanceMeasure, PerformanceMeasureExpected>> PerformanceMeasureExpectedValues;
-        public readonly List<GooglePieChartSlice> FundingSourceRequestAmountGooglePieChartSlices;
-        public readonly Models.ProjectImage KeyPhoto;
-        public readonly List<IGrouping<ProjectImageTiming, Models.ProjectImage>> ProjectImagesExceptKeyPhotoGroupedByTiming;
-        public readonly int ProjectImagesPerTimingGroup;
-        public readonly List<Models.Classification> Classifications;
-        public readonly GoogleChartJson GoogleChartJson;
-        public readonly string EstimatedTotalCost;
+        public ProjectLocationSummaryViewData ProjectLocationSummaryViewData { get; }
+        public List<IGrouping<Models.PerformanceMeasure, PerformanceMeasureExpected>> PerformanceMeasureExpectedValues { get; }
+        public List<GooglePieChartSlice> FundingSourceRequestAmountGooglePieChartSlices { get; }
+        public Models.ProjectImage KeyPhoto { get; }
+        public List<IGrouping<ProjectImageTiming, Models.ProjectImage>> ProjectImagesExceptKeyPhotoGroupedByTiming { get; }
+        public int ProjectImagesPerTimingGroup { get; }
+        public List<Models.Classification> Classifications { get; }
+        public GoogleChartJson GoogleChartJson { get; }
+        public string EstimatedTotalCost { get; }
         public string NoFundingSourceIdentified { get; }
         public string SecuredFunding { get; }
         public string UnsecuredFunding { get; }
-        public readonly string FundingRequest;
-        public readonly int CalculatedChartHeight;
-        public readonly string FactSheetPdfUrl;
+        public string FundingRequest { get; }
+        public int CalculatedChartHeight { get; }
+        public string FactSheetPdfUrl { get; }
 
-        public readonly string TaxonomyColor;
-        public readonly string TaxonomyLeafDisplayName;
-        public readonly string TaxonomyLeafName;
-        public readonly string TaxonomyBranchName;
+        public string TaxonomyColor { get; }
+        public string TaxonomyLeafDisplayName { get; }
+        public string TaxonomyLeafName { get; }
+        public string TaxonomyBranchName { get; }
 
 
         public ForwardLookingFactSheetViewData(Person currentPerson,
@@ -111,9 +111,9 @@ namespace ProjectFirma.Web.Views.Project
             TaxonomyLeafName = project.TaxonomyLeaf == null ? $"{Models.FieldDefinition.Project.GetFieldDefinitionLabel()} Taxonomy Not Set" : project.TaxonomyLeaf.DisplayName;
             TaxonomyBranchName = project.TaxonomyLeaf == null ? $"{Models.FieldDefinition.Project.GetFieldDefinitionLabel()} Taxonomy Not Set" : project.TaxonomyLeaf.TaxonomyBranch.DisplayName;
             TaxonomyLeafDisplayName = Models.FieldDefinition.TaxonomyLeaf.GetFieldDefinitionLabel();
-            EstimatedTotalCost = Project.EstimatedTotalCost.HasValue ? Project.EstimatedTotalCost.ToStringCurrency() : ViewUtilities.Unknown;
-            NoFundingSourceIdentified = project.GetNoFundingSourceIdentifiedAmount() != null ? Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency() : ViewUtilities.Unknown;
-            SecuredFunding = Project.GetSecuredFunding() != null ? Project.GetSecuredFunding().ToStringCurrency() : ViewUtilities.Unknown;
+            EstimatedTotalCost = Project.EstimatedTotalCost.HasValue ? Project.EstimatedTotalCost.ToStringCurrency() : "";
+            NoFundingSourceIdentified = project.GetNoFundingSourceIdentifiedAmount() != null ? Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency() : "";
+            SecuredFunding = Project.GetSecuredFunding() != null ? Project.GetSecuredFunding().ToStringCurrency() : "";
             UnsecuredFunding = Project.GetUnsecuredFunding().ToStringCurrency();
 
 


### PR DESCRIPTION
[projectfirma/#1335] Make funding sources more explicit on Fact Sheets

* Added Secured Funding, Unsecured Funding, and No Funding Source Identified to the Project Fact Sheet on the ForwardLookingFactSheet and on the BackwardLookingFactsheet