### PR TITLE
Fixing errors with GDAL causing unnecessary version sensitivity on GDAL uploads

### DIFF
--- a/Source/LtInfo.Common/GdalOgr/OgrInfoCommandLineRunner.cs
+++ b/Source/LtInfo.Common/GdalOgr/OgrInfoCommandLineRunner.cs
@@ -29,7 +29,9 @@ namespace LtInfo.Common.GdalOgr
     {
         public static List<string> GetFeatureClassNamesFromFileGdb(FileInfo ogrInfoFileInfo, FileInfo gdbFileInfo, double totalMilliseconds)
         {
-            var commandLineArguments = BuildOgrInfoCommandLineArgumentsToListFeatureClasses(gdbFileInfo, new DirectoryInfo(ogrInfoFileInfo.FullName));
+            // ReSharper disable once AssignNullToNotNullAttribute
+            var gdalDataDirectory = new DirectoryInfo(Path.Combine(ogrInfoFileInfo.DirectoryName, "gdal-data"));
+            var commandLineArguments = BuildOgrInfoCommandLineArgumentsToListFeatureClasses(gdbFileInfo, gdalDataDirectory);
             var processUtilityResult = ProcessUtility.ShellAndWaitImpl(ogrInfoFileInfo.DirectoryName, ogrInfoFileInfo.FullName, commandLineArguments, true, Convert.ToInt32(totalMilliseconds));
 
             var featureClassesFromFileGdb = processUtilityResult.StdOut.Split(new[] {"\r\n"}, StringSplitOptions.RemoveEmptyEntries).ToList();
@@ -41,8 +43,9 @@ namespace LtInfo.Common.GdalOgr
             using (var geoJsonFile = DisposableTempFile.MakeDisposableTempFileEndingIn(".json"))
             {
                 File.WriteAllText(geoJsonFile.FileInfo.FullName, geoJson);
-                
-                var commandLineArguments = BuildOgrInfoCommandLineArgumentsGetExtent(geoJsonFile.FileInfo, new DirectoryInfo(ogrInfoFileInfo.FullName));
+
+                var gdalDataDirectory = new DirectoryInfo(Path.Combine(ogrInfoFileInfo.DirectoryName, "gdal-data"));
+                var commandLineArguments = BuildOgrInfoCommandLineArgumentsGetExtent(geoJsonFile.FileInfo, gdalDataDirectory);
                 var processUtilityResult = ProcessUtility.ShellAndWaitImpl(ogrInfoFileInfo.DirectoryName, ogrInfoFileInfo.FullName, commandLineArguments, true, Convert.ToInt32(totalMilliseconds));
 
                 var lines = processUtilityResult.StdOut.Split(new[] {"\r\n"}, StringSplitOptions.RemoveEmptyEntries).ToList();

--- a/Source/ProjectFirma.Web/Models/BoundingBox.cs
+++ b/Source/ProjectFirma.Web/Models/BoundingBox.cs
@@ -242,7 +242,7 @@ namespace ProjectFirma.Web.Models
 
         public static BoundingBox MakeBoundingBoxFromLayerGeoJsonList(List<LayerGeoJson> layerGeoJsons)
         {
-            return !layerGeoJsons.Any() ? MakeNewDefaultBoundingBox() : new BoundingBox(layerGeoJsons.Select(x => MakeBoundingBoxFromGeoJson(x.ToGeoJsonString())).ToList());
+            return !layerGeoJsons.Any() ? MakeNewDefaultBoundingBox() : new BoundingBox(layerGeoJsons.Select(x => MakeBoundingBoxFromGeoJson(x.GetGeoJsonFeatureCollectionAsJsonString())).ToList());
         }
 
         public static void DemandIsValid(Point southWestPoint, Point northEastPoint)

--- a/Source/ProjectFirma.Web/Models/LayerGeoJson.cs
+++ b/Source/ProjectFirma.Web/Models/LayerGeoJson.cs
@@ -72,9 +72,9 @@ namespace ProjectFirmaModels.Models
             LayerType = LayerGeoJsonType.Wms;
         }
 
-        public string ToGeoJsonString()
+        public string GetGeoJsonFeatureCollectionAsJsonString()
         {
-            return JsonTools.SerializeObject(this);
+            return JsonTools.SerializeObject(GeoJsonFeatureCollection);
         }
 
         private static string GetColorString(string colorName)


### PR DESCRIPTION
- Multiple bizarre errors in GDAL handling causing crashes on GDAL 2.3.1, but not on GDAL 1.11.1.
- First error: Not specifying the GDAL_DATA command line argument correctly in all places
- Second error: When re-serializing the GeoJSON, we were serializing its CONTAINER object as well as the actual underlying GeoJSON. GDAL 1.11.1 was apparently tolerant of this, but GDAL 2.x is not.
- Adding logging to command line runners for all process, so we can see command line arguments.
- This work ported from WADNR/features/1444_detailedLocations