### PR TITLE
Features/1480 duplicate pm to primary focus area bugfix

### DIFF
--- a/Source/ProjectFirma.Web/Models/PerformanceMeasureModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/PerformanceMeasureModelExtensions.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using LtInfo.Common;
+using LtInfo.Common.Models;
 using ProjectFirma.Web.Common;
 using ProjectFirma.Web.Controllers;
 using ProjectFirma.Web.Views.Project;
@@ -120,7 +121,7 @@ namespace ProjectFirma.Web.Models
                     throw new ArgumentException();
             }
 
-            var taxonomyBranchPerformanceMeasureGroupedByLevel = performanceMeasure.TaxonomyLeafPerformanceMeasures.GroupBy(groupingFunc);
+            var taxonomyBranchPerformanceMeasureGroupedByLevel = performanceMeasure.TaxonomyLeafPerformanceMeasures.GroupBy(groupingFunc, new HavePrimaryKeyComparer<TaxonomyTier>());
             return taxonomyBranchPerformanceMeasureGroupedByLevel;
         }
 

--- a/Source/ProjectFirma.Web/Models/TaxonomyTier.cs
+++ b/Source/ProjectFirma.Web/Models/TaxonomyTier.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using LtInfo.Common.Models;
 using ProjectFirmaModels.Models;
 
 namespace ProjectFirma.Web.Models
 {
-    public class TaxonomyTier
+    public class TaxonomyTier : IHavePrimaryKey
     {
+
         public int TaxonomyTierID { get; }
         public string ThemeColor { get; }
         public string DisplayName { get; }
@@ -83,5 +85,7 @@ namespace ProjectFirma.Web.Models
             TaxonomyBranch = null;
             TaxonomyTrunk = taxonomyTrunk;
         }
+
+        public int PrimaryKey => TaxonomyTierID;
     }
 }


### PR DESCRIPTION
Duplicate taxonomy branches were being displayed because the taxonomy leafs (the level of the PM to taxonomy relationships) were not grouping as they should. 