### PR TITLE
Features/274 import nta attachments pork

### DIFF
--- a/Source/ProjectFirma.Web/Models/TaxonomyLeafModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/TaxonomyLeafModelExtensions.cs
@@ -192,5 +192,16 @@ namespace ProjectFirma.Web.Models
             };
             return fancyTreeNode;
         }
+
+        public static string GetTaxonomyLeafCodeAndName(this TaxonomyLeaf taxonomyLeaf)
+        {
+            return taxonomyLeaf.TaxonomyLeafCode + ": " + taxonomyLeaf.TaxonomyLeafName;
+        }
+
+        public static string GetTaxonomyBranchCodeAndName(this TaxonomyLeaf taxonomyLeaf)
+        {
+            return taxonomyLeaf.TaxonomyBranch.TaxonomyBranchCode + ": " +
+                   taxonomyLeaf.TaxonomyBranch.TaxonomyBranchName;
+        }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectDocument/NewProjectDocument.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectDocument/NewProjectDocument.cshtml
@@ -7,7 +7,10 @@
 @using (Html.BeginForm())
 {
     <div class="form-horizontal">
-        @Html.HiddenFor(m=>m.ParentID)
+        <div>
+            You can upload a range of document formats here, including some image formats (for diagrams, plans, illustrations). However, we encourage you to upload photos in the Photos section.
+        </div>
+        @Html.HiddenFor(m => m.ParentID)
         <div class="form-group">
             <div class="col-xs-12 col-sm-3 control-label">
                 @Html.LabelWithSugarFor(m => m.File)

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectDocument/NewProjectDocumentViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectDocument/NewProjectDocumentViewModel.cs
@@ -15,7 +15,7 @@ namespace ProjectFirma.Web.Views.Shared.ProjectDocument
     {
         [Required]
         [DisplayName("File")]
-        [SitkaFileExtensions("pdf|zip|doc|docx|xls|xlsx")]
+        [SitkaFileExtensions("doc|docx|jpg|jpeg|pdf|ppt|pptx|png|tif|xls|xlsx|zip")]
         public HttpPostedFileBase File { get; set; }
 
         [Required]

--- a/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexGridSpec.cs
@@ -49,7 +49,7 @@ namespace ProjectFirma.Web.Views.TaxonomyLeaf
                 Add(FieldDefinitionEnum.TaxonomyBranch.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.TaxonomyBranch.GetDetailUrl(), a.TaxonomyBranch.TaxonomyBranchName), 300);
             }
             Add(FieldDefinitionEnum.TaxonomyLeaf.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.TaxonomyLeafName), 350, DhtmlxGridColumnFilterType.Html);
-            Add("Description", a => a.TaxonomyLeafDescriptionHtmlString, 350);
+            Add("Description", a => a.TaxonomyLeafDescriptionHtmlString, 0);
             Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", a => a.GetAssociatedProjects(currentPerson).Count, 90);
             Add($"# of {FieldDefinitionEnum.PerformanceMeasure.ToType().GetFieldDefinitionLabelPluralized()}", a => a.TaxonomyLeafPerformanceMeasures.Count, 90);
             Add("Sort Order", a => a.TaxonomyLeafSortOrder, 90, DhtmlxGridColumnFormatType.None);

--- a/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexGridSpec.cs
@@ -46,9 +46,9 @@ namespace ProjectFirma.Web.Views.TaxonomyLeaf
             }
             if (!MultiTenantHelpers.IsTaxonomyLevelLeaf())
             {
-                Add(FieldDefinitionEnum.TaxonomyBranch.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.TaxonomyBranch.GetDetailUrl(), a.TaxonomyBranch.TaxonomyBranchName), 300);
+                Add(FieldDefinitionEnum.TaxonomyBranch.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.TaxonomyBranch.GetDetailUrl(), a.GetTaxonomyBranchCodeAndName()), 300);
             }
-            Add(FieldDefinitionEnum.TaxonomyLeaf.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.TaxonomyLeafName), 350, DhtmlxGridColumnFilterType.Html);
+            Add(FieldDefinitionEnum.TaxonomyLeaf.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.GetTaxonomyLeafCodeAndName()), 350, DhtmlxGridColumnFilterType.Html);
             Add("Description", a => a.TaxonomyLeafDescriptionHtmlString, 0);
             Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", a => a.GetAssociatedProjects(currentPerson).Count, 90);
             Add($"# of {FieldDefinitionEnum.PerformanceMeasure.ToType().GetFieldDefinitionLabelPluralized()}", a => a.TaxonomyLeafPerformanceMeasures.Count, 90);

--- a/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexGridSpec.cs
@@ -49,10 +49,10 @@ namespace ProjectFirma.Web.Views.TaxonomyLeaf
                 Add(FieldDefinitionEnum.TaxonomyBranch.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.TaxonomyBranch.GetDetailUrl(), a.GetTaxonomyBranchCodeAndName()), 300);
             }
             Add(FieldDefinitionEnum.TaxonomyLeaf.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.GetTaxonomyLeafCodeAndName()), 350, DhtmlxGridColumnFilterType.Html);
-            Add("Description", a => a.TaxonomyLeafDescription, 0);
             Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", a => a.GetAssociatedProjects(currentPerson).Count, 90);
             Add($"# of {FieldDefinitionEnum.PerformanceMeasure.ToType().GetFieldDefinitionLabelPluralized()}", a => a.TaxonomyLeafPerformanceMeasures.Count, 90);
             Add("Sort Order", a => a.TaxonomyLeafSortOrder, 90, DhtmlxGridColumnFormatType.None);
+            Add("Description", a => a.TaxonomyLeafDescription, 100);
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexGridSpec.cs
@@ -49,7 +49,7 @@ namespace ProjectFirma.Web.Views.TaxonomyLeaf
                 Add(FieldDefinitionEnum.TaxonomyBranch.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.TaxonomyBranch.GetDetailUrl(), a.GetTaxonomyBranchCodeAndName()), 300);
             }
             Add(FieldDefinitionEnum.TaxonomyLeaf.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.GetTaxonomyLeafCodeAndName()), 350, DhtmlxGridColumnFilterType.Html);
-            Add("Description", a => a.TaxonomyLeafDescriptionHtmlString, 0);
+            Add("Description", a => a.TaxonomyLeafDescription, 0);
             Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", a => a.GetAssociatedProjects(currentPerson).Count, 90);
             Add($"# of {FieldDefinitionEnum.PerformanceMeasure.ToType().GetFieldDefinitionLabelPluralized()}", a => a.TaxonomyLeafPerformanceMeasures.Count, 90);
             Add("Sort Order", a => a.TaxonomyLeafSortOrder, 90, DhtmlxGridColumnFormatType.None);


### PR DESCRIPTION
- Added the codes to the Taxonomy Branch and Leafs
- Description field is moved to end of grid with width of 100
- Added "JPG, JPEG, PNG, TIF, PPTX, PPT " and alphabetized acceptable Document Attachment formats
- Added “You can upload a range of document formats here, including some image formats (for diagrams, plans, illustrations). However, we encourage you to upload photos in the Photos section.” as static text in document upload. 

Ill handle the extra pork of changing "View All Indicators" to "All Indicators" in a different story related to vital signs