### PR TITLE
Updated deletion to have the message

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/FundingSourceController.cs
+++ b/Source/ProjectFirma.Web/Controllers/FundingSourceController.cs
@@ -176,12 +176,12 @@ namespace ProjectFirma.Web.Controllers
 
         private PartialViewResult ViewDeleteFundingSource(FundingSource fundingSource, ConfirmDialogFormViewModel viewModel)
         {
-            var canDelete = !fundingSource.HasDependentObjects();
-            var confirmMessage = canDelete
-                ? $"Are you sure you want to delete this {FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()} '{fundingSource.FundingSourceName}'?"
-                : ConfirmDialogFormViewData.GetStandardCannotDeleteMessage($"{FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()}", SitkaRoute<FundingSourceController>.BuildLinkFromExpression(x => x.Detail(fundingSource), "here"));
 
-            var viewData = new ConfirmDialogFormViewData(confirmMessage, canDelete);
+            var numberOfProjectsAssociated = fundingSource.GetAssociatedProjects(CurrentPerson).Count;
+            var confirmMessage =
+                $"This {FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()} is associated with {numberOfProjectsAssociated} Projects. Deleting the Funding Source will delete all associated expenditure records. Are you sure you wish to delete {FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()} '{fundingSource.FundingSourceName}'?";
+
+            var viewData = new ConfirmDialogFormViewData(confirmMessage);
             return RazorPartialView<ConfirmDialogForm, ConfirmDialogFormViewData, ConfirmDialogFormViewModel>(viewData, viewModel);
         }
 
@@ -196,7 +196,9 @@ namespace ProjectFirma.Web.Controllers
             {
                 return ViewDeleteFundingSource(fundingSource, viewModel);
             }
+
             fundingSource.DeleteFull(HttpRequestStorage.DatabaseEntities);
+
             SetMessageForDisplay($"{FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()} {name} successfully deleted.");
             return new ModalDialogFormJsonResult();
         }

--- a/Source/ProjectFirma.Web/Views/FundingSource/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/FundingSource/IndexGridSpec.cs
@@ -37,7 +37,7 @@ namespace ProjectFirma.Web.Views.FundingSource
             var fundingSourceEditFeature = new FundingSourceEditFeature();
             if (fundingSourceEditFeature.HasPermissionByPerson(currentPerson))
             {
-                Add(string.Empty, x => DhtmlxGridHtmlHelpers.MakeDeleteIconAndLinkBootstrap(x.GetDeleteUrl(), fundingSourceEditFeature.HasPermission(currentPerson, x).HasPermission, !x.HasDependentObjects()), 30, DhtmlxGridColumnFilterType.None);
+                Add(string.Empty, x => DhtmlxGridHtmlHelpers.MakeDeleteIconAndLinkBootstrap(x.GetDeleteUrl(), fundingSourceEditFeature.HasPermission(currentPerson, x).HasPermission, true), 30, DhtmlxGridColumnFilterType.None);
             }
 
             Add(FieldDefinitionEnum.FundingSource.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.GetDisplayName()), 320, DhtmlxGridColumnFilterType.Html);


### PR DESCRIPTION
"This Funding Source is associated with {n} Projects. Deleting the Funding Source will delete all associated expenditure records. Are you sure you wish to delete Funding Source {funding source name}?"

and took out the check to see if they can delete the funding source
made the trashcan icon blue by setting the deletePossibleForObject parameter true in gridspec