### PR TITLE
Bug Fix for saving Reported Expenditures in Project Create workflow

### DIFF
--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpendituresValidationResult.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpendituresValidationResult.cs
@@ -59,7 +59,9 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
             List<IFundingSourceExpenditure> projectFundingSourceExpenditures)
         {
             var errors = new List<string>();
-            var fundingSources = projectFundingSourceExpenditures.Select(x => x.FundingSource).GroupBy(x => x.FundingSourceID).Select(x => x.First()).ToList();
+            var fundingSourcesIDs = projectFundingSourceExpenditures.Select(x => x.FundingSourceID).Distinct().ToList();
+            var fundingSources =
+                HttpRequestStorage.DatabaseEntities.FundingSources.Where(x => fundingSourcesIDs.Contains(x.FundingSourceID));
 
             // validation 1: ensure that we have expenditure values from ProjectUpdate start year to min(endyear, currentyear)
             if (projectExemptReportingYearSimples.Any(x => x.IsExempt) && string.IsNullOrWhiteSpace(explanation))

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpendituresValidationResult.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpendituresValidationResult.cs
@@ -59,6 +59,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
             List<IFundingSourceExpenditure> projectFundingSourceExpenditures)
         {
             var errors = new List<string>();
+            // Need to get FundingSources by IDs because we may have unsaved projectFundingSourceExpenditures that won't have a reference to the entity
             var fundingSourcesIDs = projectFundingSourceExpenditures.Select(x => x.FundingSourceID).Distinct().ToList();
             var fundingSources =
                 HttpRequestStorage.DatabaseEntities.FundingSources.Where(x => fundingSourcesIDs.Contains(x.FundingSourceID));


### PR DESCRIPTION
Reverted change from revision 49c65ab30a8fc17b768a6a76d62110da4d7b646b on 6/6/2019. This code is called from the ProjectCreate as well as ProjectUpdate workflow. In ProjectUpdate, the projectFundingSourceExpenditures have been saved to the database by the time this is called. In the ProjectCreate workflow, the projectFundingSourceExpenditures have not been saved yet, so need to use x.FundingSourceID because will x.FundingSource will be null in ProjectCreate.