### PR TITLE
[projectfirma/#1682] Update project create and update wizard navigati…

### DIFF
--- a/Database/LookupTables/dbo.ProjectCreateSection.sql
+++ b/Database/LookupTables/dbo.ProjectCreateSection.sql
@@ -8,7 +8,7 @@ values
 (5, 'LocationDetailed', 'Detailed Location', 40, 0, 2),
 (6, 'ExpectedAccomplishments', 'Expected Accomplishments', 60, 0, 3),
 (7, 'ReportedAccomplishments', 'Reported Accomplishments', 70, 1, 3),
-(8, 'ExpectedFunding', 'Budget', 80, 0, 4),
+(8, 'Budget', 'Budget', 80, 0, 4),
 (9, 'ReportedExpenditures', 'Reported Expenditures', 90, 1, 4),
 (11, 'Classifications', 'Classifications', 110, 1, 5),
 (12, 'Assessment', 'Asssessment', 120, 1, 5),

--- a/Database/LookupTables/dbo.ProjectUpdateSection.sql
+++ b/Database/LookupTables/dbo.ProjectUpdateSection.sql
@@ -7,7 +7,7 @@ values
 (4, 'Organizations', 'Organizations', 40, 1, 1),
 (5, 'LocationDetailed', 'Detailed Location', 50, 0, 2),
 (6, 'ReportedAccomplishments', 'Reported Accomplishments', 70, 1, 3),
-(7, 'ExpectedFunding', 'Budget', 70, 0, 4),
+(7, 'Budget', 'Budget', 70, 0, 4),
 (8, 'Expenditures', 'Expenditures', 80, 1, 4),
 (9, 'Photos', 'Photos', 100, 0, 5),
 (10, 'ExternalLinks', 'External Links', 125, 0, 5),

--- a/Database/LookupTables/dbo.ProjectWorkflowSectionGrouping.sql
+++ b/Database/LookupTables/dbo.ProjectWorkflowSectionGrouping.sql
@@ -5,5 +5,5 @@ values
 (1, 'Overview', 'Overview', 10),
 (2, 'SpatialInformation', 'Spatial Information', 20),
 (3, 'Accomplishments', 'Accomplishments', 30),
-(4, 'Expenditures', 'Financials', 40),
+(4, 'Financials', 'Financials', 40),
 (5, 'AdditionalData', 'Additional Data', 50)

--- a/Source/ProjectFirma.Api/Controllers/ProjectDto.cs
+++ b/Source/ProjectFirma.Api/Controllers/ProjectDto.cs
@@ -42,7 +42,7 @@ namespace ProjectFirma.Api.Controllers
             DetailUrl = $"/Project/Detail/{project.ProjectID}";
             EstimatedTotalCost = project.EstimatedTotalCost;
             SecuredFunding = project.GetSecuredFunding();
-            NoFundingSourceIdentifiedFunding = project.GetNoFundingSourceIdentifiedFunding();
+            NoFundingSourceIdentifiedFunding = project.GetNoFundingSourceIdentifiedAmount();
             if (project.ProjectLocationPoint != null)
             {
                 LocationPointAsGeoJsonFeature = DbGeometryToGeoJsonHelper.FromDbGeometry(project.ProjectLocationPoint);

--- a/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
@@ -499,7 +499,7 @@ namespace ProjectFirma.Web.Controllers
             var allProjectFundingSourceRequests = HttpRequestStorage.DatabaseEntities.AllProjectFundingSourceRequests.Local;
             viewModel.UpdateModel(project, projectFundingSourceRequests, allProjectFundingSourceRequests);
             SetMessageForDisplay("Expected Funding successfully saved.");
-            return GoToNextSection(viewModel, project, ProjectCreateSection.ExpectedFunding.ProjectCreateSectionDisplayName);
+            return GoToNextSection(viewModel, project, ProjectCreateSection.Budget.ProjectCreateSectionDisplayName);
         }
 
         [HttpGet]

--- a/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
@@ -715,7 +715,7 @@ namespace ProjectFirma.Web.Controllers
             }
 
             return TickleLastUpdateDateAndGoToNextSection(viewModel, projectUpdateBatch,
-                ProjectUpdateSection.ExpectedFunding.ProjectUpdateSectionDisplayName);
+                ProjectUpdateSection.Budget.ProjectUpdateSectionDisplayName);
         }
 
         private ViewResult ViewExpectedFunding(ProjectUpdateBatch projectUpdateBatch, ExpectedFundingViewModel viewModel)

--- a/Source/ProjectFirma.Web/Models/ProjectCreateSectionModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectCreateSectionModelExtensions.cs
@@ -37,7 +37,7 @@ namespace ProjectFirma.Web.Models
                         ProjectID = project.ProjectID
                     }.GetValidationResults();
                     return !pmValidationResults.Any();
-                case ProjectCreateSectionEnum.ExpectedFunding:
+                case ProjectCreateSectionEnum.Budget:
                     // todo: more complicated than that.
                     return ProjectCreateSection.Basics.IsComplete(project);
                 case ProjectCreateSectionEnum.ReportedExpenditures:
@@ -82,7 +82,7 @@ namespace ProjectFirma.Web.Models
                     return ProjectCreateSection.Basics.IsComplete(project) ? SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.ExpectedPerformanceMeasures(project.ProjectID)) : null;
                 case ProjectCreateSectionEnum.ReportedAccomplishments:
                     return ProjectCreateSection.Basics.IsComplete(project) ? SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.PerformanceMeasures(project.ProjectID)) : null;
-                case ProjectCreateSectionEnum.ExpectedFunding:
+                case ProjectCreateSectionEnum.Budget:
                     return ProjectCreateSection.Basics.IsComplete(project) ? SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.ExpectedFunding(project.ProjectID)) : null;
                 case ProjectCreateSectionEnum.ReportedExpenditures:
                     return ProjectCreateSection.Basics.IsComplete(project) ? SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.Expenditures(project.ProjectID)) : null;

--- a/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
@@ -389,7 +389,7 @@ namespace ProjectFirmaModels.Models
             if (noFundingSourceIdentifiedAmount > 0)
             {
                 var sortOrder = requestAmountsDictionary.Any() ? requestAmountsDictionary.Max(x => x.SortOrder) + 1 : 0;
-                requestAmountsDictionary.Add(new GooglePieChartSlice("No Funding Source Identified Yet", noFundingSourceIdentifiedAmount, sortOrder, "#dbdbdb"));
+                requestAmountsDictionary.Add(new GooglePieChartSlice(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().GetFieldDefinitionLabel(), noFundingSourceIdentifiedAmount, sortOrder, "#dbdbdb"));
             }
             return requestAmountsDictionary;
         }

--- a/Source/ProjectFirma.Web/Models/ProjectUpdateSectionModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectUpdateSectionModelExtensions.cs
@@ -26,7 +26,7 @@ namespace ProjectFirma.Web.Models
                     return true;
                 case ProjectUpdateSectionEnum.ReportedAccomplishments:
                     return projectUpdateBatch.AreReportedPerformanceMeasuresValid();
-                case ProjectUpdateSectionEnum.ExpectedFunding:
+                case ProjectUpdateSectionEnum.Budget:
                     return true;
                 case ProjectUpdateSectionEnum.Expenditures:
                     return projectUpdateBatch.AreExpendituresValid();
@@ -64,7 +64,7 @@ namespace ProjectFirma.Web.Models
                     return SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.LocationDetailed(project));
                 case ProjectUpdateSectionEnum.ReportedAccomplishments:
                     return SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.ReportedPerformanceMeasures(project));
-                case ProjectUpdateSectionEnum.ExpectedFunding:
+                case ProjectUpdateSectionEnum.Budget:
                     return SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.ExpectedFunding(project));
                 case ProjectUpdateSectionEnum.Expenditures:
                     return SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.Expenditures(project));

--- a/Source/ProjectFirma.Web/Models/ProjectWorkflowSectionGroupingModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectWorkflowSectionGroupingModelExtensions.cs
@@ -33,11 +33,11 @@ namespace ProjectFirma.Web.Models
                         projectCreateSectionsForAdditionalData.Add(ProjectCreateSection.Assessment);
                     }
                     return GetProjectCreateSectionsImpl(project, projectCreateSectionsForAdditionalData, ignoreStatus);
-                case ProjectWorkflowSectionGroupingEnum.Expenditures:
-                    var projectCreateSectionsForExpenditures = projectWorkflowSectionGrouping.ProjectCreateSections.Except(new List<ProjectCreateSection> { ProjectCreateSection.ExpectedFunding, ProjectCreateSection.ReportedExpenditures }).ToList();
+                case ProjectWorkflowSectionGroupingEnum.Financials:
+                    var projectCreateSectionsForExpenditures = projectWorkflowSectionGrouping.ProjectCreateSections.Except(new List<ProjectCreateSection> { ProjectCreateSection.Budget, ProjectCreateSection.ReportedExpenditures }).ToList();
                     if (project != null && project.IsExpectedFundingRelevant())
                     {
-                        projectCreateSectionsForExpenditures.Add(ProjectCreateSection.ExpectedFunding);
+                        projectCreateSectionsForExpenditures.Add(ProjectCreateSection.Budget);
                     }
 
                     if (project != null && project.AreReportedExpendituresRelevant())
@@ -121,11 +121,11 @@ namespace ProjectFirma.Web.Models
                         projectUpdateSectionsForPerformanceMeasures.Add(ProjectUpdateSection.ReportedAccomplishments);
                     }
                     return GetProjectUpdateSectionsImpl(projectUpdateBatch, projectUpdateSectionsForPerformanceMeasures, projectUpdateStatus, ignoreStatus);
-                case ProjectWorkflowSectionGroupingEnum.Expenditures:
-                    var projectUpdateSectionsForExpenditures = projectWorkflowSectionGrouping.ProjectUpdateSections.Except(new List<ProjectUpdateSection> { ProjectUpdateSection.ExpectedFunding }).ToList();
+                case ProjectWorkflowSectionGroupingEnum.Financials:
+                    var projectUpdateSectionsForExpenditures = projectWorkflowSectionGrouping.ProjectUpdateSections.Except(new List<ProjectUpdateSection> { ProjectUpdateSection.Budget }).ToList();
                     if (projectUpdateBatch.Project.IsExpectedFundingRelevant())
                     {
-                        projectUpdateSectionsForExpenditures.Add(ProjectUpdateSection.ExpectedFunding);
+                        projectUpdateSectionsForExpenditures.Add(ProjectUpdateSection.Budget);
                     }
                     return GetProjectUpdateSectionsImpl(projectUpdateBatch, projectUpdateSectionsForExpenditures, projectUpdateStatus, ignoreStatus);
                 case ProjectWorkflowSectionGroupingEnum.AdditionalData:

--- a/Source/ProjectFirma.Web/Views/Organization/ProjectsIncludingLeadImplementingGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/ProjectsIncludingLeadImplementingGridSpec.cs
@@ -63,7 +63,8 @@ namespace ProjectFirma.Web.Views.Organization
             Add(FieldDefinitionEnum.FundingType.ToType().ToGridHeaderString(), x => x.FundingType.GetFundingTypeShortName(), 80, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(FieldDefinitionEnum.EstimatedTotalCost.ToType().ToGridHeaderString(), x => x.EstimatedTotalCost, 85, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.SecuredFunding.ToType().ToGridHeaderString(), x => x.GetSecuredFunding(), 85, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
-            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedFunding(), 85, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.TargetedFunding.ToType().ToGridHeaderString(), x => x.GetTargetedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedAmount(), 85, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             foreach (var geospatialAreaType in new List<GeospatialAreaType>())
             {
                 Add($"{geospatialAreaType.GeospatialAreaTypeNamePluralized}", a => a.GetProjectGeospatialAreaNamesAsHyperlinks(geospatialAreaType), 350, DhtmlxGridColumnFilterType.Html);

--- a/Source/ProjectFirma.Web/Views/Project/BasicProjectInfoGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/BasicProjectInfoGridSpec.cs
@@ -60,7 +60,8 @@ namespace ProjectFirma.Web.Views.Project
             Add(FieldDefinitionEnum.FundingType.ToType().ToGridHeaderString(), x => x.FundingType.GetFundingTypeShortName(), 80, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(FieldDefinitionEnum.EstimatedTotalCost.ToType().ToGridHeaderString(), x => x.EstimatedTotalCost, 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.SecuredFunding.ToType().ToGridHeaderString(), x => x.GetSecuredFunding(), 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
-            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedFunding(), 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.TargetedFunding.ToType().ToGridHeaderString(), x => x.GetTargetedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedAmount(), 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             foreach (var geospatialAreaType in new List<GeospatialAreaType>())
             {
                 Add($"{geospatialAreaType.GeospatialAreaTypeNamePluralized}", a => a.GetProjectGeospatialAreaNamesAsHyperlinks(geospatialAreaType), 350, DhtmlxGridColumnFilterType.Html);

--- a/Source/ProjectFirma.Web/Views/Project/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Project/Detail.cshtml
@@ -273,7 +273,7 @@
                     </div>
                 }
 
-                <h2 class="sectionHeader">Funding</h2>
+                <h2 class="sectionHeader">Financials</h2>
                 <div class="panel panelFirma">
                     <div class="panel-heading panelTitle">
                         <h3>
@@ -291,12 +291,12 @@
                             <div class="col-xs-6 col-sm-2 text-right">@ViewDataTyped.Project.GetSecuredFunding().ToStringCurrency()</div>
                         </div>
                         <div class="row">
+                            <label class="col-xs-6 col-sm-3 text-right">@Html.LabelWithSugarFor(FieldDefinitionEnum.TargetedFunding.ToType())</label>
+                            <div class="col-xs-6 col-sm-2 text-right">@ViewDataTyped.Project.GetTargetedFunding().ToStringCurrency()</div>
+                        </div>
+                        <div class="row">
                             <label class="col-xs-6 col-sm-3 text-right">@Html.LabelWithSugarFor(FieldDefinitionEnum.NoFundingSourceIdentified.ToType())</label>
-                            <div class="col-xs-6 col-sm-2 text-right">@ViewDataTyped.Project.GetNoFundingSourceIdentifiedFunding().ToStringCurrency()</div>
-                            @if (ViewDataTyped.Project.GetTargetedFunding() > 0)
-                            {
-                                <div class="col-sm-6">(@ViewDataTyped.Project.GetTargetedFunding().ToStringCurrency() identified as @Html.LabelWithSugarFor(FieldDefinitionEnum.TargetedFunding.ToType()))</div>
-                            }
+                            <div class="col-xs-6 col-sm-2 text-right">@ViewDataTyped.Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency()</div>                            
                         </div>
                         <hr />
                         @{

--- a/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheet.cshtml
+++ b/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheet.cshtml
@@ -341,7 +341,7 @@
         </div>
         <div class="col-sm-12 col-md-6">
             <div style="margin-left: auto; margin-right: auto; page-break-inside: avoid">
-                <h4>@ViewDataTyped.TargetedFundingLabel</h4>
+                <h4>Budget</h4>
                 <div class="chartPanel">
                     @if (ViewDataTyped.FundingSourceRequestAmountGooglePieChartSlices.Any())
                     {
@@ -353,7 +353,7 @@
                     else
                     {
                         <div class="text-center">
-                            <p class="systemText">No @ViewDataTyped.TargetedFundingLabel Sources identified</p>
+                            <p class="systemText">No @(FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized()) identified for this @(FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()).</p>
                         </div>
                     }
                 </div>

--- a/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
@@ -140,7 +140,7 @@ namespace ProjectFirma.Web.Views.Project
                 foreach (var googlePieChartSlice in FundingSourceRequestAmountGooglePieChartSlices.OrderBy(x => x.SortOrder))
                 {
                     legendHtml += "<div class='chartLegendColorBox' style='display:inline-block; border: solid 6px " + googlePieChartSlice.Color + "'></div> ";
-                    legendHtml += "<div style='display:inline-block' >" + googlePieChartSlice.Label + "</div>";
+                    legendHtml += "<div style='display:inline-block' >" + googlePieChartSlice.Value.ToStringCurrency() + " " + googlePieChartSlice.Label + "</div>";
                     legendHtml += "<br>";
                 }
                 legendHtml += "</div>";

--- a/Source/ProjectFirma.Web/Views/Project/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/IndexGridSpec.cs
@@ -87,7 +87,8 @@ namespace ProjectFirma.Web.Views.Project
             Add(FieldDefinitionEnum.FundingType.ToType().ToGridHeaderString(), x => fundingTypes[x.FundingTypeID].FundingTypeShortName, 80, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(FieldDefinitionEnum.EstimatedTotalCost.ToType().ToGridHeaderString(), x => x.EstimatedTotalCost, 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.SecuredFunding.ToType().ToGridHeaderString(), x => x.GetSecuredFunding(), 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
-            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedFunding(), 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.TargetedFunding.ToType().ToGridHeaderString(), x => x.GetTargetedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedAmount(), 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             foreach (var projectCustomAttributeType in projectCustomAttributeTypes.OrderBy(x => x.ProjectCustomAttributeTypeName))
             {
                 if (projectCustomAttributeType.IncludeInProjectGrid && projectCustomAttributeType.HasViewPermission(currentPerson))

--- a/Source/ProjectFirma.Web/Views/Project/PendingGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/PendingGridSpec.cs
@@ -51,7 +51,8 @@ namespace ProjectFirma.Web.Views.Project
             Add(FieldDefinitionEnum.CompletionYear.ToType().ToGridHeaderString(), x => ProjectModelExtensions.GetCompletionYear(x), 90, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(FieldDefinitionEnum.EstimatedTotalCost.ToType().ToGridHeaderString(), x => x.EstimatedTotalCost, 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.SecuredFunding.ToType().ToGridHeaderString(), x => x.GetSecuredFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
-            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.TargetedFunding.ToType().ToGridHeaderString(), x => x.GetTargetedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedAmount(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             
             Add("Submitted Date", a => a.SubmissionDate, 120);
             Add("Last Updated", a => a.GetLastUpdateDate(), 120);

--- a/Source/ProjectFirma.Web/Views/Project/ProjectExcelSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ProjectExcelSpec.cs
@@ -68,7 +68,8 @@ namespace ProjectFirma.Web.Views.Project
             AddColumn(FieldDefinitionEnum.FundingType.ToType().GetFieldDefinitionLabel(), x => x.FundingType.GetFundingTypeShortName());
             AddColumn(FieldDefinitionEnum.EstimatedTotalCost.ToType().GetFieldDefinitionLabel(), x => x.EstimatedTotalCost);
             AddColumn(FieldDefinitionEnum.SecuredFunding.ToType().GetFieldDefinitionLabel(), x => x.GetSecuredFunding());
-            AddColumn(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().GetFieldDefinitionLabel(), x => x.GetNoFundingSourceIdentifiedFunding());
+            AddColumn(FieldDefinitionEnum.TargetedFunding.ToType().ToGridHeaderString(), x => x.GetTargetedFunding());
+            AddColumn(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().GetFieldDefinitionLabel(), x => x.GetNoFundingSourceIdentifiedAmount());
             AddColumn("State", a => a.GetProjectLocationStateProvince());
             AddColumn($"{FieldDefinitionEnum.ProjectLocation.ToType().GetFieldDefinitionLabel()} Notes", a => a.ProjectLocationNotes);
         }

--- a/Source/ProjectFirma.Web/Views/Project/ProposalsGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ProposalsGridSpec.cs
@@ -54,7 +54,8 @@ namespace ProjectFirma.Web.Views.Project
             Add(FieldDefinitionEnum.CompletionYear.ToType().ToGridHeaderString(), x => ProjectFirmaModels.Models.ProjectModelExtensions.GetCompletionYear(x), 90, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(FieldDefinitionEnum.EstimatedTotalCost.ToType().ToGridHeaderString(), x => x.EstimatedTotalCost, 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.SecuredFunding.ToType().ToGridHeaderString(), x => x.GetSecuredFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
-            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.TargetedFunding.ToType().ToGridHeaderString(), x => x.GetTargetedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedAmount(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add("Proposed By", a => a.ProposingPerson.GetFullNameFirstLastAndOrgShortNameAsUrl(), 200);
             Add("Proposed Date", a => a.ProposingDate, 120);
             Add("Submitted Date", a => a.SubmissionDate, 120);

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ExpectedFundingViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ExpectedFundingViewData.cs
@@ -35,7 +35,7 @@ namespace ProjectFirma.Web.Views.ProjectCreate
         public ExpectedFundingViewData(Person currentPerson,
             ProjectFirmaModels.Models.Project project,
             ProposalSectionsStatus proposalSectionsStatus,
-            ViewDataForAngularClass viewDataForAngularClass) : base(currentPerson, project, ProjectCreateSection.ExpectedFunding.ProjectCreateSectionDisplayName, proposalSectionsStatus)
+            ViewDataForAngularClass viewDataForAngularClass) : base(currentPerson, project, ProjectCreateSection.Budget.ProjectCreateSectionDisplayName, proposalSectionsStatus)
         {
             ViewDataForAngular = viewDataForAngularClass;
             RequestFundingSourceUrl = SitkaRoute<HelpController>.BuildUrlFromExpression(x => x.MissingFundingSource());

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/Expenditures.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/Expenditures.cshtml
@@ -55,7 +55,7 @@ To enter your @FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()'s 
     {
         <div style="width: 300px">@FieldDefinitionEnum.EstimatedTotalCost.ToType().GetFieldDefinitionLabel(): <span style="float: right; font-weight: bold">@ViewDataTyped.Project.EstimatedTotalCost.ToStringCurrency()</span></div>
         <div style="width: 300px">@FieldDefinitionEnum.SecuredFunding.ToType().GetFieldDefinitionLabel(): <span style="float: right; font-weight: bold">@ViewDataTyped.Project.GetSecuredFunding().ToStringCurrency()</span></div>
-        <div style="width: 300px">@FieldDefinitionEnum.NoFundingSourceIdentified.ToType().GetFieldDefinitionLabel(): <span style="float: right; font-weight: bold">@ViewDataTyped.Project.GetNoFundingSourceIdentifiedFunding().ToStringCurrency()</span></div>
+        <div style="width: 300px">@FieldDefinitionEnum.NoFundingSourceIdentified.ToType().GetFieldDefinitionLabel(): <span style="float: right; font-weight: bold">@ViewDataTyped.Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency()</span></div>
     }
     else if (ViewDataTyped.Project.FundingTypeID == (int) FundingTypeEnum.OperationsAndMaintenance)
     {

--- a/Source/ProjectFirma.Web/Views/ProjectFunding/ProjectFundingDetail.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectFunding/ProjectFundingDetail.cshtml
@@ -35,13 +35,13 @@
                     <th style="text-align: right">@Html.LabelWithSugarFor(FieldDefinitionEnum.TargetedFunding.ToType())</th>
                     <th class="text-right">Total</th>
                 </tr>
-                @foreach (var projectFundingSourceRequest in ViewDataTyped.FundingSourceRequestAmounts.OrderBy(x => x.FundingSource.GetDisplayName()))
+                @foreach (var projectFundingSourceBudget in ViewDataTyped.FundingSourceRequestAmounts.OrderBy(x => x.FundingSource.GetDisplayName()))
                 {
                     <tr>
-                        <td>@Html.Raw(projectFundingSourceRequest.FundingSource.GetDisplayNameAsUrl())</td>
-                        <th class="text-right">@projectFundingSourceRequest.SecuredAmount.ToStringCurrency()</th>
-                        <th class="text-right">@projectFundingSourceRequest.UnsecuredAmount.ToStringCurrency()</th>
-                        <th class="text-right">@((projectFundingSourceRequest.UnsecuredAmount + projectFundingSourceRequest.SecuredAmount).ToStringCurrency())</th>
+                        <td>@Html.Raw(projectFundingSourceBudget.FundingSource.GetDisplayNameAsUrl())</td>
+                        <th class="text-right">@projectFundingSourceBudget.SecuredAmount.ToStringCurrency()</th>
+                        <th class="text-right">@projectFundingSourceBudget.UnsecuredAmount.ToStringCurrency()</th>
+                        <th class="text-right">@(((projectFundingSourceBudget.UnsecuredAmount ?? 0) + (projectFundingSourceBudget.SecuredAmount ?? 0)).ToStringCurrency())</th>
                     </tr>
                 }
                 @if (ViewDataTyped.FundingSourceRequestAmounts.Any())
@@ -50,7 +50,7 @@
                         <th>Total</th>
                         <th class="text-right">@ViewDataTyped.FundingSourceRequestAmounts.Sum(x => x.SecuredAmount).ToStringCurrency()</th>
                         <th class="text-right">@ViewDataTyped.FundingSourceRequestAmounts.Sum(x => x.UnsecuredAmount).ToStringCurrency()</th>
-                        <th class="text-right">@ViewDataTyped.FundingSourceRequestAmounts.Sum(x => x.SecuredAmount + x.UnsecuredAmount).ToStringCurrency()</th>
+                        <th class="text-right">@((ViewDataTyped.FundingSourceRequestAmounts.Sum(x => x.SecuredAmount) + ViewDataTyped.FundingSourceRequestAmounts.Sum(x => x.UnsecuredAmount)).ToStringCurrency())</th>
                     </tr>
                 }
             </table>

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpectedFundingViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpectedFundingViewData.cs
@@ -39,7 +39,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
         public readonly SectionCommentsViewData SectionCommentsViewData;
         
         public ExpectedFundingViewData(Person currentPerson, ProjectUpdateBatch projectUpdateBatch, ViewDataForAngularClass viewDataForAngularClass, ProjectFundingDetailViewData projectFundingDetailViewData, ProjectUpdateStatus projectUpdateStatus, ExpectedFundingValidationResult expectedFundingValidationResult)
-            : base(currentPerson, projectUpdateBatch, projectUpdateStatus, expectedFundingValidationResult.GetWarningMessages(), ProjectUpdateSection.ExpectedFunding.ProjectUpdateSectionDisplayName)
+            : base(currentPerson, projectUpdateBatch, projectUpdateStatus, expectedFundingValidationResult.GetWarningMessages(), ProjectUpdateSection.Budget.ProjectUpdateSectionDisplayName)
         {
             ViewDataForAngular = viewDataForAngularClass;
             RefreshUrl = SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.RefreshExpectedFunding(projectUpdateBatch.Project));

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectControls/ProjectBasics.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectControls/ProjectBasics.cshtml
@@ -119,7 +119,7 @@ Source code is available upon request via <support@sitkatech.com>.
                 @Html.LabelWithSugarFor(FieldDefinitionEnum.NoFundingSourceIdentified.ToType())
             </div>
             <div class="col-xs-6">
-                @ViewDataTyped.Project.GetNoFundingSourceIdentifiedFunding().ToStringCurrency()
+                @ViewDataTyped.Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency()
             </div>
         </div>
     }

--- a/Source/ProjectFirma.Web/Views/TaxonomyLeaf/ProjectForTaxonomyLeafGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyLeaf/ProjectForTaxonomyLeafGridSpec.cs
@@ -45,7 +45,8 @@ namespace ProjectFirma.Web.Views.TaxonomyLeaf
             Add(FieldDefinitionEnum.FundingType.ToType().ToGridHeaderString(), x => x.FundingType.GetFundingTypeShortName(), 80, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(FieldDefinitionEnum.EstimatedTotalCost.ToType().ToGridHeaderString(), x => x.EstimatedTotalCost, 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.SecuredFunding.ToType().ToGridHeaderString(), x => x.GetSecuredFunding(), 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
-            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedFunding(), 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.TargetedFunding.ToType().ToGridHeaderString(), x => x.GetTargetedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
+            Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedAmount(), 110, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             foreach (var geospatialAreaType in new List<GeospatialAreaType>())
             {
                 Add($"{geospatialAreaType.GeospatialAreaTypeNamePluralized}", a => a.GetProjectGeospatialAreaNamesAsHyperlinks(geospatialAreaType), 350, DhtmlxGridColumnFilterType.Html);

--- a/Source/ProjectFirmaModels/Models/Generated/ProjectCreateSection.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/ProjectCreateSection.Binding.cs
@@ -24,7 +24,7 @@ namespace ProjectFirmaModels.Models
         public static readonly ProjectCreateSectionLocationDetailed LocationDetailed = ProjectCreateSectionLocationDetailed.Instance;
         public static readonly ProjectCreateSectionExpectedAccomplishments ExpectedAccomplishments = ProjectCreateSectionExpectedAccomplishments.Instance;
         public static readonly ProjectCreateSectionReportedAccomplishments ReportedAccomplishments = ProjectCreateSectionReportedAccomplishments.Instance;
-        public static readonly ProjectCreateSectionExpectedFunding ExpectedFunding = ProjectCreateSectionExpectedFunding.Instance;
+        public static readonly ProjectCreateSectionBudget Budget = ProjectCreateSectionBudget.Instance;
         public static readonly ProjectCreateSectionReportedExpenditures ReportedExpenditures = ProjectCreateSectionReportedExpenditures.Instance;
         public static readonly ProjectCreateSectionClassifications Classifications = ProjectCreateSectionClassifications.Instance;
         public static readonly ProjectCreateSectionAssessment Assessment = ProjectCreateSectionAssessment.Instance;
@@ -39,7 +39,7 @@ namespace ProjectFirmaModels.Models
         /// </summary>
         static ProjectCreateSection()
         {
-            All = new List<ProjectCreateSection> { Basics, LocationSimple, Organizations, LocationDetailed, ExpectedAccomplishments, ReportedAccomplishments, ExpectedFunding, ReportedExpenditures, Classifications, Assessment, Photos, NotesAndDocuments };
+            All = new List<ProjectCreateSection> { Basics, LocationSimple, Organizations, LocationDetailed, ExpectedAccomplishments, ReportedAccomplishments, Budget, ReportedExpenditures, Classifications, Assessment, Photos, NotesAndDocuments };
             AllLookupDictionary = new ReadOnlyDictionary<int, ProjectCreateSection>(All.ToDictionary(x => x.ProjectCreateSectionID));
         }
 
@@ -119,12 +119,12 @@ namespace ProjectFirmaModels.Models
                     return Assessment;
                 case ProjectCreateSectionEnum.Basics:
                     return Basics;
+                case ProjectCreateSectionEnum.Budget:
+                    return Budget;
                 case ProjectCreateSectionEnum.Classifications:
                     return Classifications;
                 case ProjectCreateSectionEnum.ExpectedAccomplishments:
                     return ExpectedAccomplishments;
-                case ProjectCreateSectionEnum.ExpectedFunding:
-                    return ExpectedFunding;
                 case ProjectCreateSectionEnum.LocationDetailed:
                     return LocationDetailed;
                 case ProjectCreateSectionEnum.LocationSimple:
@@ -153,7 +153,7 @@ namespace ProjectFirmaModels.Models
         LocationDetailed = 5,
         ExpectedAccomplishments = 6,
         ReportedAccomplishments = 7,
-        ExpectedFunding = 8,
+        Budget = 8,
         ReportedExpenditures = 9,
         Classifications = 11,
         Assessment = 12,
@@ -197,10 +197,10 @@ namespace ProjectFirmaModels.Models
         public static readonly ProjectCreateSectionReportedAccomplishments Instance = new ProjectCreateSectionReportedAccomplishments(7, @"ReportedAccomplishments", @"Reported Accomplishments", 70, true, 3);
     }
 
-    public partial class ProjectCreateSectionExpectedFunding : ProjectCreateSection
+    public partial class ProjectCreateSectionBudget : ProjectCreateSection
     {
-        private ProjectCreateSectionExpectedFunding(int projectCreateSectionID, string projectCreateSectionName, string projectCreateSectionDisplayName, int sortOrder, bool hasCompletionStatus, int projectWorkflowSectionGroupingID) : base(projectCreateSectionID, projectCreateSectionName, projectCreateSectionDisplayName, sortOrder, hasCompletionStatus, projectWorkflowSectionGroupingID) {}
-        public static readonly ProjectCreateSectionExpectedFunding Instance = new ProjectCreateSectionExpectedFunding(8, @"ExpectedFunding", @"Budget", 80, false, 4);
+        private ProjectCreateSectionBudget(int projectCreateSectionID, string projectCreateSectionName, string projectCreateSectionDisplayName, int sortOrder, bool hasCompletionStatus, int projectWorkflowSectionGroupingID) : base(projectCreateSectionID, projectCreateSectionName, projectCreateSectionDisplayName, sortOrder, hasCompletionStatus, projectWorkflowSectionGroupingID) {}
+        public static readonly ProjectCreateSectionBudget Instance = new ProjectCreateSectionBudget(8, @"Budget", @"Budget", 80, false, 4);
     }
 
     public partial class ProjectCreateSectionReportedExpenditures : ProjectCreateSection

--- a/Source/ProjectFirmaModels/Models/Generated/ProjectUpdateSection.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/ProjectUpdateSection.Binding.cs
@@ -23,7 +23,7 @@ namespace ProjectFirmaModels.Models
         public static readonly ProjectUpdateSectionOrganizations Organizations = ProjectUpdateSectionOrganizations.Instance;
         public static readonly ProjectUpdateSectionLocationDetailed LocationDetailed = ProjectUpdateSectionLocationDetailed.Instance;
         public static readonly ProjectUpdateSectionReportedAccomplishments ReportedAccomplishments = ProjectUpdateSectionReportedAccomplishments.Instance;
-        public static readonly ProjectUpdateSectionExpectedFunding ExpectedFunding = ProjectUpdateSectionExpectedFunding.Instance;
+        public static readonly ProjectUpdateSectionBudget Budget = ProjectUpdateSectionBudget.Instance;
         public static readonly ProjectUpdateSectionExpenditures Expenditures = ProjectUpdateSectionExpenditures.Instance;
         public static readonly ProjectUpdateSectionPhotos Photos = ProjectUpdateSectionPhotos.Instance;
         public static readonly ProjectUpdateSectionExternalLinks ExternalLinks = ProjectUpdateSectionExternalLinks.Instance;
@@ -39,7 +39,7 @@ namespace ProjectFirmaModels.Models
         /// </summary>
         static ProjectUpdateSection()
         {
-            All = new List<ProjectUpdateSection> { Basics, LocationSimple, Organizations, LocationDetailed, ReportedAccomplishments, ExpectedFunding, Expenditures, Photos, ExternalLinks, NotesAndDocuments, ExpectedAccomplishments, TechnicalAssistanceRequests };
+            All = new List<ProjectUpdateSection> { Basics, LocationSimple, Organizations, LocationDetailed, ReportedAccomplishments, Budget, Expenditures, Photos, ExternalLinks, NotesAndDocuments, ExpectedAccomplishments, TechnicalAssistanceRequests };
             AllLookupDictionary = new ReadOnlyDictionary<int, ProjectUpdateSection>(All.ToDictionary(x => x.ProjectUpdateSectionID));
         }
 
@@ -117,10 +117,10 @@ namespace ProjectFirmaModels.Models
             {
                 case ProjectUpdateSectionEnum.Basics:
                     return Basics;
+                case ProjectUpdateSectionEnum.Budget:
+                    return Budget;
                 case ProjectUpdateSectionEnum.ExpectedAccomplishments:
                     return ExpectedAccomplishments;
-                case ProjectUpdateSectionEnum.ExpectedFunding:
-                    return ExpectedFunding;
                 case ProjectUpdateSectionEnum.Expenditures:
                     return Expenditures;
                 case ProjectUpdateSectionEnum.ExternalLinks:
@@ -152,7 +152,7 @@ namespace ProjectFirmaModels.Models
         Organizations = 4,
         LocationDetailed = 5,
         ReportedAccomplishments = 6,
-        ExpectedFunding = 7,
+        Budget = 7,
         Expenditures = 8,
         Photos = 9,
         ExternalLinks = 10,
@@ -191,10 +191,10 @@ namespace ProjectFirmaModels.Models
         public static readonly ProjectUpdateSectionReportedAccomplishments Instance = new ProjectUpdateSectionReportedAccomplishments(6, @"ReportedAccomplishments", @"Reported Accomplishments", 70, true, 3);
     }
 
-    public partial class ProjectUpdateSectionExpectedFunding : ProjectUpdateSection
+    public partial class ProjectUpdateSectionBudget : ProjectUpdateSection
     {
-        private ProjectUpdateSectionExpectedFunding(int projectUpdateSectionID, string projectUpdateSectionName, string projectUpdateSectionDisplayName, int sortOrder, bool hasCompletionStatus, int projectWorkflowSectionGroupingID) : base(projectUpdateSectionID, projectUpdateSectionName, projectUpdateSectionDisplayName, sortOrder, hasCompletionStatus, projectWorkflowSectionGroupingID) {}
-        public static readonly ProjectUpdateSectionExpectedFunding Instance = new ProjectUpdateSectionExpectedFunding(7, @"ExpectedFunding", @"Budget", 70, false, 4);
+        private ProjectUpdateSectionBudget(int projectUpdateSectionID, string projectUpdateSectionName, string projectUpdateSectionDisplayName, int sortOrder, bool hasCompletionStatus, int projectWorkflowSectionGroupingID) : base(projectUpdateSectionID, projectUpdateSectionName, projectUpdateSectionDisplayName, sortOrder, hasCompletionStatus, projectWorkflowSectionGroupingID) {}
+        public static readonly ProjectUpdateSectionBudget Instance = new ProjectUpdateSectionBudget(7, @"Budget", @"Budget", 70, false, 4);
     }
 
     public partial class ProjectUpdateSectionExpenditures : ProjectUpdateSection

--- a/Source/ProjectFirmaModels/Models/Generated/ProjectWorkflowSectionGrouping.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/ProjectWorkflowSectionGrouping.Binding.cs
@@ -21,7 +21,7 @@ namespace ProjectFirmaModels.Models
         public static readonly ProjectWorkflowSectionGroupingOverview Overview = ProjectWorkflowSectionGroupingOverview.Instance;
         public static readonly ProjectWorkflowSectionGroupingSpatialInformation SpatialInformation = ProjectWorkflowSectionGroupingSpatialInformation.Instance;
         public static readonly ProjectWorkflowSectionGroupingAccomplishments Accomplishments = ProjectWorkflowSectionGroupingAccomplishments.Instance;
-        public static readonly ProjectWorkflowSectionGroupingExpenditures Expenditures = ProjectWorkflowSectionGroupingExpenditures.Instance;
+        public static readonly ProjectWorkflowSectionGroupingFinancials Financials = ProjectWorkflowSectionGroupingFinancials.Instance;
         public static readonly ProjectWorkflowSectionGroupingAdditionalData AdditionalData = ProjectWorkflowSectionGroupingAdditionalData.Instance;
 
         public static readonly List<ProjectWorkflowSectionGrouping> All;
@@ -32,7 +32,7 @@ namespace ProjectFirmaModels.Models
         /// </summary>
         static ProjectWorkflowSectionGrouping()
         {
-            All = new List<ProjectWorkflowSectionGrouping> { Overview, SpatialInformation, Accomplishments, Expenditures, AdditionalData };
+            All = new List<ProjectWorkflowSectionGrouping> { Overview, SpatialInformation, Accomplishments, Financials, AdditionalData };
             AllLookupDictionary = new ReadOnlyDictionary<int, ProjectWorkflowSectionGrouping>(All.ToDictionary(x => x.ProjectWorkflowSectionGroupingID));
         }
 
@@ -109,8 +109,8 @@ namespace ProjectFirmaModels.Models
                     return Accomplishments;
                 case ProjectWorkflowSectionGroupingEnum.AdditionalData:
                     return AdditionalData;
-                case ProjectWorkflowSectionGroupingEnum.Expenditures:
-                    return Expenditures;
+                case ProjectWorkflowSectionGroupingEnum.Financials:
+                    return Financials;
                 case ProjectWorkflowSectionGroupingEnum.Overview:
                     return Overview;
                 case ProjectWorkflowSectionGroupingEnum.SpatialInformation:
@@ -126,7 +126,7 @@ namespace ProjectFirmaModels.Models
         Overview = 1,
         SpatialInformation = 2,
         Accomplishments = 3,
-        Expenditures = 4,
+        Financials = 4,
         AdditionalData = 5
     }
 
@@ -148,10 +148,10 @@ namespace ProjectFirmaModels.Models
         public static readonly ProjectWorkflowSectionGroupingAccomplishments Instance = new ProjectWorkflowSectionGroupingAccomplishments(3, @"Accomplishments", @"Accomplishments", 30);
     }
 
-    public partial class ProjectWorkflowSectionGroupingExpenditures : ProjectWorkflowSectionGrouping
+    public partial class ProjectWorkflowSectionGroupingFinancials : ProjectWorkflowSectionGrouping
     {
-        private ProjectWorkflowSectionGroupingExpenditures(int projectWorkflowSectionGroupingID, string projectWorkflowSectionGroupingName, string projectWorkflowSectionGroupingDisplayName, int sortOrder) : base(projectWorkflowSectionGroupingID, projectWorkflowSectionGroupingName, projectWorkflowSectionGroupingDisplayName, sortOrder) {}
-        public static readonly ProjectWorkflowSectionGroupingExpenditures Instance = new ProjectWorkflowSectionGroupingExpenditures(4, @"Expenditures", @"Financials", 40);
+        private ProjectWorkflowSectionGroupingFinancials(int projectWorkflowSectionGroupingID, string projectWorkflowSectionGroupingName, string projectWorkflowSectionGroupingDisplayName, int sortOrder) : base(projectWorkflowSectionGroupingID, projectWorkflowSectionGroupingName, projectWorkflowSectionGroupingDisplayName, sortOrder) {}
+        public static readonly ProjectWorkflowSectionGroupingFinancials Instance = new ProjectWorkflowSectionGroupingFinancials(4, @"Financials", @"Financials", 40);
     }
 
     public partial class ProjectWorkflowSectionGroupingAdditionalData : ProjectWorkflowSectionGrouping

--- a/Source/ProjectFirmaModels/Models/Project.cs
+++ b/Source/ProjectFirmaModels/Models/Project.cs
@@ -46,11 +46,6 @@ namespace ProjectFirmaModels.Models
         public Person GetPrimaryContact() => PrimaryContactPerson ??
                                              GetPrimaryContactOrganization()?.PrimaryContactPerson;
 
-        public decimal? GetNoFundingSourceIdentifiedFunding()
-        {
-            return EstimatedTotalCost - GetSecuredFunding();
-        }
-
         public decimal? GetSecuredFunding()
         {
             return ProjectFundingSourceRequests.Any() ? (decimal?)ProjectFundingSourceRequests.Sum(x => x.SecuredAmount.GetValueOrDefault()) : 0;

--- a/Source/ProjectFirmaModels/Models/ProjectUpdateSection.cs
+++ b/Source/ProjectFirmaModels/Models/ProjectUpdateSection.cs
@@ -77,7 +77,7 @@
         }
     }
 
-    public partial class ProjectUpdateSectionExpectedFunding
+    public partial class ProjectUpdateSectionBudget
     {
         public override bool SectionIsUpdated(ProjectUpdateStatus projectUpdateStatus)
         {


### PR DESCRIPTION
…on, page names and default labels

Rename ProjectCreateSection and ProjectUpdateSection to Budget
Remove confusingly redundant method on a project to calculate the unfunded need, add targeted funding to grids
Fix addition bug on project detail budget funding roll up
Rename Funding section on Project detail page to "Financials" to align with Project Update and Create
Rename the forward looking fact sheet financial data section to Budget to align with the Project Detail page