### PR TITLE
Bug fix for editing custom attributes as non-admin user

### DIFF
--- a/Database/ReleaseScript/0271 - Add unqiue constraints to ProjectCustomAttribute and FundingSourceCustomAttribute.sql
+++ b/Database/ReleaseScript/0271 - Add unqiue constraints to ProjectCustomAttribute and FundingSourceCustomAttribute.sql
@@ -1,0 +1,9 @@
+USE [ProjectFirma]
+
+-- can have only one row per TenantID, ProjectID, ProjectCustomAttributeTypeID
+ALTER TABLE dbo.ProjectCustomAttribute
+ADD CONSTRAINT AK_ProjectCustomAttribute_TenantID_ProjectID_ProjectCustomAttributeTypeID UNIQUE (TenantID, ProjectID, ProjectCustomAttributeTypeID)
+
+-- can have only one row per TenantID, FundingSourceID, FundingSourceCustomAttributeTypeID
+ALTER TABLE dbo.FundingSourceCustomAttribute
+ADD CONSTRAINT AK_ProjectCustomAttribute_TenantID_FundingSourceID_FundingSourceCustomAttributeTypeID UNIQUE (TenantID, FundingSourceID, FundingSourceCustomAttributeTypeID)

--- a/Source/ProjectFirma.Web/Controllers/FundingSourceCustomAttributesController.cs
+++ b/Source/ProjectFirma.Web/Controllers/FundingSourceCustomAttributesController.cs
@@ -67,7 +67,7 @@ namespace ProjectFirma.Web.Controllers
         private PartialViewResult ViewEditFundingSourceCustomAttibutes(FundingSource fundingSource, EditFundingSourceCustomAttributesViewModel viewModel)
         {
 
-            var fundingSourceCustomAttributeTypes = HttpRequestStorage.DatabaseEntities.FundingSourceCustomAttributeTypes.ToList().Where(x => x.HasViewPermission(CurrentPerson));
+            var fundingSourceCustomAttributeTypes = HttpRequestStorage.DatabaseEntities.FundingSourceCustomAttributeTypes.ToList().Where(x => x.HasEditPermission(CurrentPerson));
 
             var viewData = new EditFundingSourceCustomAttributesViewData(
                 fundingSourceCustomAttributeTypes,

--- a/Source/ProjectFirma.Web/Controllers/ProjectCustomAttributesController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCustomAttributesController.cs
@@ -65,7 +65,7 @@ namespace ProjectFirma.Web.Controllers
         private PartialViewResult ViewEditProjectCustomAttibutes(Project project, EditProjectCustomAttributesViewModel viewModel)
         {
 
-            var projectCustomAttributeTypes = HttpRequestStorage.DatabaseEntities.ProjectCustomAttributeTypes.ToList().Where(x => x.HasViewPermission(CurrentPerson));
+            var projectCustomAttributeTypes = HttpRequestStorage.DatabaseEntities.ProjectCustomAttributeTypes.ToList().Where(x => x.HasEditPermission(CurrentPerson));
 
             var viewData = new EditProjectCustomAttributesViewData(
                 projectCustomAttributeTypes.ToList(),


### PR DESCRIPTION
bug fix: editor modals for custom attributes should only show types that user has permission to edit. Added constraints to the database to prevent duplicate rows that break the UI.