### PR TITLE
Funding Source Custom Attributes no long have an Editable By field in the UI

### DIFF
--- a/Source/ProjectFirma.Web/Views/FundingSourceCustomAttributeType/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/FundingSourceCustomAttributeType/Detail.cshtml
@@ -65,10 +65,6 @@
                     <div class="col-sm-9">@ViewDataTyped.FundingSourceCustomAttributeType.FundingSourceCustomAttributeTypeDescription</div>
                 </div>
                 <div class="row">
-                    <label class="col-sm-3 control-label text-right">@Html.LabelWithSugarFor(FieldDefinitionEnum.FundingSourceCustomAttributeTypeEditableBy.ToType())</label>
-                    <div class="col-sm-9">@ViewDataTyped.FundingSourceCustomAttributeType.GetEditableRoles()</div>
-                </div>
-                <div class="row">
                     <label class="col-sm-3 control-label text-right">@Html.LabelWithSugarFor(FieldDefinitionEnum.FundingSourceCustomAttributeTypeViewableBy.ToType())</label>
                     <div class="col-sm-9">@ViewDataTyped.FundingSourceCustomAttributeType.GetViewableRoles()</div>
                 </div>

--- a/Source/ProjectFirma.Web/Views/FundingSourceCustomAttributeType/Edit.cshtml
+++ b/Source/ProjectFirma.Web/Views/FundingSourceCustomAttributeType/Edit.cshtml
@@ -140,15 +140,6 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <div class="col-sm-3 control-label">
-                        @Html.LabelWithSugarFor(@FieldDefinitionEnum.FundingSourceCustomAttributeTypeEditableBy.ToType())
-                    </div>
-                    <div class="col-sm-9">
-                        @Html.CheckBoxFor(x => x.EditableByNormal) @Html.LabelFor(x => x.EditableByNormal, new {style = "font-weight : normal; padding-right : 10px;"})
-                        @Html.CheckBoxFor(x => x.EditableByProjectSteward) @Html.LabelFor(x => x.EditableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" })
-                    </div>
-                </div>
-                <div class="form-group">
                     <div class="col-sm-3 control-label">                       
                         @Html.LabelWithSugarFor(@FieldDefinitionEnum.FundingSourceCustomAttributeTypeViewableBy.ToType())
                     </div>

--- a/Source/ProjectFirma.Web/Views/FundingSourceCustomAttributeType/FundingSourceCustomAttributeTypeGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/FundingSourceCustomAttributeType/FundingSourceCustomAttributeTypeGridSpec.cs
@@ -20,7 +20,6 @@ namespace ProjectFirma.Web.Views.FundingSourceCustomAttributeType
             Add(FieldDefinitionEnum.FundingSourceCustomAttributeDataType.ToType().ToGridHeaderString(), a => a.FundingSourceCustomAttributeDataType.FundingSourceCustomAttributeDataTypeDisplayName, 100, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(FieldDefinitionEnum.MeasurementUnit.ToType().ToGridHeaderString(), a => a.GetMeasurementUnitDisplayName(), 100, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add("Required?", a => a.IsRequired.ToYesNo(), 100, DhtmlxGridColumnFilterType.SelectFilterHtmlStrict);
-            Add(FieldDefinitionEnum.FundingSourceCustomAttributeTypeEditableBy.ToType().ToGridHeaderString(), x => x.GetEditableRoles(), 150, DhtmlxGridColumnFilterType.Html);
             Add(FieldDefinitionEnum.FundingSourceCustomAttributeTypeViewableBy.ToType().ToGridHeaderString(), a => a.GetViewableRoles(), 200, DhtmlxGridColumnFilterType.Html);
             Add($"Include In {FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()} Grid?", a => a.IncludeInFundingSourceGrid.ToYesNo() ?? ViewUtilities.NoAnswerProvided, 100, DhtmlxGridColumnFilterType.SelectFilterStrict);
         }


### PR DESCRIPTION
Removed concept of Editable By for Funding Source Custom Attibutes from the UI (left the database schema intact incase we want to have the Editable By for Funding Source Custom Attributes in the future (currently have it for Project Custom Attributes)