### PR TITLE
Allow negative currency input for NoFundingSourceIdentifiedYet 

### DIFF
--- a/Source/ProjectFirma.Web/Content/angular/ng-currency.js
+++ b/Source/ProjectFirma.Web/Content/angular/ng-currency.js
@@ -57,4 +57,67 @@ angular.module("ng-currency", [])
                 });
             }
         };
+    })
+    .directive("ngCurrencyAllowNegative", function ($filter, $locale) {
+        return {
+            require: "ngModel",
+            link: function (scope, element, attrs, ngModel) {
+                function decimalRex(dChar) {
+                    return RegExp("\\d|\\" + dChar, "g");
+                }
+
+                function clearRex(dChar) {
+                    return RegExp("((\\" + dChar + ")|([0-9]{1,}\\" + dChar + "?))&?[0-9]{0,2}", "g");
+                }
+
+                function decimalSepRex(dChar) {
+                    return RegExp("\\" + dChar, "g");
+                }
+
+                function negativeRex() {
+                    return RegExp("^\\(.{0,}\\)$|-", "g");
+                }
+
+                function clearValue(value) {
+                    value = value.toString();
+                    var dSeparator = $locale.NUMBER_FORMATS.DECIMAL_SEP;
+                    var clear;
+
+                    if (value.match(decimalSepRex(dSeparator))) {
+                        clear = value.match(decimalRex(dSeparator))
+                            .join("").match(clearRex(dSeparator));
+                        clear = clear ? clear[0].replace(dSeparator, ".") : "";
+                    }
+                    else if (value.match(decimalSepRex("."))) {
+                        clear = value.match(decimalRex("."))
+                            .join("").match(clearRex("."));
+                        clear = clear ? clear[0] : "";
+                    }
+                    else {
+                        clear = value.match(/\d/g);
+                        clear = clear ? clear.join("") : "";
+                    }
+
+                    if (value.match(negativeRex())) {
+                        // original value was negative. add minus sign
+                        clear = "-" + clear;
+                    }
+
+                    return clear;
+                }
+
+                ngModel.$parsers.push(function (viewValue) {
+                    var cVal = clearValue(viewValue);
+                    return Sitka.Methods.isUndefinedNullOrEmpty(cVal) ? null : parseFloat(cVal).toFixed(2);
+                });
+
+                element.on("blur", function () {
+                    element.val($filter('currency')(ngModel.$modelValue));
+                });
+
+                ngModel.$formatters.unshift(function (value) {
+                    return $filter('currency')(value);
+                });
+            }
+        };
     });

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ExpectedFunding.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ExpectedFunding.cshtml
@@ -163,7 +163,7 @@ Source code is available upon request via <support@sitkatech.com>.
                 <td></td>
                 <td>@Html.LabelWithSugarFor(FieldDefinitionEnum.NoFundingSourceIdentified.ToType())</td>
                 <td style="text-align: right;">
-                    <input type="text" style="text-align: right" ng-model="AngularModel.NoFundingSourceIdentifiedYet" class="sitkaCurrency form-control" ng-currency />
+                    <input type="text" style="text-align: right" ng-model="AngularModel.NoFundingSourceIdentifiedYet" class="sitkaCurrency form-control" ng-currency-allow-negative />
                 </td>
             </tr>
             <tr>

--- a/Source/ProjectFirma.Web/Views/ProjectFundingSourceBudget/EditProjectFundingSourceBudget.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectFundingSourceBudget/EditProjectFundingSourceBudget.cshtml
@@ -166,8 +166,8 @@ Source code is available upon request via <support@sitkatech.com>.
                     <tr>
                         <td></td>
                         <td>@Html.LabelWithSugarFor(FieldDefinitionEnum.NoFundingSourceIdentified.ToType())</td>
-                        <td style="text-align: right; padding-right: 17px; width: auto;">
-                            <input type="text" style="text-align: right;" ng-model="AngularModel.NoFundingSourceIdentifiedYet" class="sitkaCurrency form-control" ng-currency />
+                        <td style="text-align: right; padding-right: 17px;">
+                            <input type="text" style="text-align: right; width: auto;" ng-model="AngularModel.NoFundingSourceIdentifiedYet" class="sitkaCurrency form-control" ng-currency-allow-negative/>
                         </td>
                     </tr>
                     <tr>

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpectedFunding.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpectedFunding.cshtml
@@ -184,7 +184,7 @@ else if (ViewDataTyped.AreProjectBasicsValid)
                     <td></td>
                     <td>@Html.LabelWithSugarFor(FieldDefinitionEnum.NoFundingSourceIdentified.ToType())</td>
                     <td style="text-align: right;">
-                        <input type="text" style="text-align: right" ng-model="AngularModel.NoFundingSourceIdentifiedYet" class="sitkaCurrency form-control" ng-currency/>
+                        <input type="text" style="text-align: right" ng-model="AngularModel.NoFundingSourceIdentifiedYet" class="sitkaCurrency form-control" ng-currency-allow-negative/>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
created a directive to allow negative values for currency. Use it for all NoFundingSourceIdentifiedYet input fields.  This directive is almost a copy of ngCurrency, but checks for any "-" in the string, or if the values is surrounded by parentheses (e.g. "($100,000)" ) to indicate a negative value.