### PR TITLE
Features/1681 update fact sheet for new budget types

### DIFF
--- a/Source/ProjectFirma.Web/Models/FundingSourceModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/FundingSourceModelExtensions.cs
@@ -44,9 +44,9 @@ namespace ProjectFirma.Web.Models
             }
 
             var organizationShortNameIfAvailable = $"({fundingSource.Organization.GetOrganizationShortNameIfAvailable()})";
-            return organizationShortNameIfAvailable.Length < 45
-                ? $"{fundingSource.FundingSourceName.ToEllipsifiedString(45 - organizationShortNameIfAvailable.Length)} {organizationShortNameIfAvailable}"
-                : $"{fundingSource.FundingSourceName} {organizationShortNameIfAvailable}";
+            return organizationShortNameIfAvailable.Length < 35
+                ? $"{fundingSource.FundingSourceName.ToEllipsifiedString(35 - organizationShortNameIfAvailable.Length)} {organizationShortNameIfAvailable}"
+                : $"{organizationShortNameIfAvailable}";
         }
 
 

--- a/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
@@ -382,14 +382,19 @@ namespace ProjectFirma.Web.Models
             var securedColorHsl = new { hue = 96.0, sat = 60.0 };
             var targetedColorHsl = new { hue = 33.3, sat = 240.0 };
 
+            var showFullName = (securedAmountsDictionary.Count + targetedAmountsDictionary.Count) <= 2;
+
             var securedPieChartSlices = securedAmountsDictionary.OrderBy(x => x.Key.FundingSourceName).Select((fundingSourceDictionaryItem, index) =>
             {
                 var fundingSource = fundingSourceDictionaryItem.Key;
                 var fundingAmount = fundingSourceDictionaryItem.Value;
+                var displayName = showFullName
+                    ? fundingSource.GetDisplayName()
+                    : fundingSource.GetFixedLengthDisplayName();
 
                 var luminosity = 100.0 * (securedAmountsDictionary.Count - index - 1) / securedAmountsDictionary.Count + 120;
                 var color = ColorTranslator.ToHtml(new HslColor(securedColorHsl.hue, securedColorHsl.sat, luminosity));
-                return new GooglePieChartSlice("Secured Funding: " + fundingSource.GetFixedLengthDisplayName(), Convert.ToDouble(fundingAmount), sortOrder++, color);
+                return new GooglePieChartSlice(@FieldDefinitionEnum.SecuredFunding.ToType().GetFieldDefinitionLabel() + ": " + displayName, Convert.ToDouble(fundingAmount), sortOrder++, color);
 
             }).ToList();
             googlePieChartSlices.AddRange(securedPieChartSlices);
@@ -398,10 +403,13 @@ namespace ProjectFirma.Web.Models
             {
                 var fundingSource = fundingSourceDictionaryItem.Key;
                 var fundingAmount = fundingSourceDictionaryItem.Value;
+                var displayName = showFullName
+                    ? fundingSource.GetDisplayName()
+                    : fundingSource.GetFixedLengthDisplayName();
 
                 var luminosity = 100.0 * (targetedAmountsDictionary.Count - index - 1) / targetedAmountsDictionary.Count + 120;
                 var color = ColorTranslator.ToHtml(new HslColor(targetedColorHsl.hue, targetedColorHsl.sat, luminosity));
-                return new GooglePieChartSlice(@FieldDefinitionEnum.TargetedFunding.ToType().GetFieldDefinitionLabel() + ": " + fundingSource.GetFixedLengthDisplayName(), Convert.ToDouble(fundingAmount), sortOrder++, color);
+                return new GooglePieChartSlice(@FieldDefinitionEnum.TargetedFunding.ToType().GetFieldDefinitionLabel() + ": " + displayName, Convert.ToDouble(fundingAmount), sortOrder++, color);
             }).ToList();
             googlePieChartSlices.AddRange(targetedPieChartSlices);
 

--- a/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheet.cshtml
+++ b/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheet.cshtml
@@ -188,7 +188,7 @@
             </div>
             <div class="row">
                 <div class="col-xs-12 col-sm-6 col-md-3">
-                    <strong>@FieldDefinitionEnum.EstimatedTotalCost.ToType().GetFieldDefinitionLabel()</strong>
+                    <strong>@ViewDataTyped.EstimatedTotalCostLabel</strong>
                 </div>
                 <div class="col-xs-12 col-sm-6 col-md-3">
                     @ViewDataTyped.EstimatedTotalCost

--- a/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
@@ -47,6 +47,7 @@ namespace ProjectFirma.Web.Views.Project
         public GoogleChartJson GoogleChartJson { get; }
         public string EstimatedTotalCost { get; }
 
+        public string EstimatedTotalCostLabel { get; }
         public string NoFundingSourceIdentifiedLabel { get; }
         public string NoFundingSourceIdentified { get; }
         public string SecuredFunding { get; }
@@ -90,10 +91,12 @@ namespace ProjectFirma.Web.Views.Project
             GoogleChartJson = googleChartJson;
             FundingSourceRequestAmountGooglePieChartSlices = fundingSourceRequestAmountGooglePieChartSlices;
 
+            var labelUsesFullDisplayName = FundingSourceRequestAmountGooglePieChartSlices.Count <= 2 || 
+                                           FundingSourceRequestAmountGooglePieChartSlices.Count <=3 && fundingSourceRequestAmountGooglePieChartSlices.Any(x => x.Label.Equals(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().GetFieldDefinitionLabel()));
             //Dynamically resize chart based on how much space the legend requires
-            CalculatedChartHeight = 350 - (FundingSourceRequestAmountGooglePieChartSlices.Count <= 2
-                                        ? FundingSourceRequestAmountGooglePieChartSlices.Count * 24
-                                        : FundingSourceRequestAmountGooglePieChartSlices.Count * 20);
+            CalculatedChartHeight = 400 - (labelUsesFullDisplayName
+                                        ? FundingSourceRequestAmountGooglePieChartSlices.Count * 52
+                                        : FundingSourceRequestAmountGooglePieChartSlices.Count * 18);
             FactSheetPdfUrl = SitkaRoute<ProjectController>.BuildUrlFromExpression(c => c.FactSheetPdf(project));
 
             if (project.TaxonomyLeaf == null)
@@ -120,6 +123,10 @@ namespace ProjectFirma.Web.Views.Project
             TaxonomyBranchName = project.TaxonomyLeaf == null ? $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} Taxonomy Not Set" : project.TaxonomyLeaf.TaxonomyBranch.GetDisplayName();
             TaxonomyLeafDisplayName = FieldDefinitionEnum.TaxonomyLeaf.ToType().GetFieldDefinitionLabel();
             EstimatedTotalCost = Project.GetEstimatedTotalCost().HasValue ? Project.GetEstimatedTotalCost().ToStringCurrency() : "";
+            EstimatedTotalCostLabel =
+                Project.FundingTypeID.HasValue && Project.FundingType.ToEnum == FundingTypeEnum.BudgetSameEachYear
+                    ? FieldDefinitionEnum.EstimatedAnnualOperatingCost.ToType().GetFieldDefinitionLabel()
+                    : FieldDefinitionEnum.EstimatedTotalCost.ToType().GetFieldDefinitionLabel();
             NoFundingSourceIdentifiedLabel = FieldDefinitionEnum.NoFundingSourceIdentified.ToType().GetFieldDefinitionLabel();
             NoFundingSourceIdentified = project.GetNoFundingSourceIdentifiedAmount() != null ? Project.GetNoFundingSourceIdentifiedAmount().ToStringCurrency() : "";
             SecuredFunding = Project.GetSecuredFunding().ToStringCurrency();


### PR DESCRIPTION
Update fact sheet to align with new budget types: 

- use custom labels everywhere
- updated legend so long names are ellipsified sooner, only the short name is displayed if the short name is really long (more than 35 characters), if there 2 or less funding sources, we display the full name without ellipsification (adjusted CalculatedChartHeight accordingly)