### PR TITLE
[projectfirma/#1659] Bug fix: add lead implementer to featured projects

### DIFF
--- a/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
@@ -798,8 +798,7 @@ namespace ProjectFirma.Web.Models
         public static Dictionary<OrganizationType, List<decimal>> GetFundingForAllProjectsByOwnerOrgType(Person currentPerson)
         {
             var ownerOrgRelationshipType =
-                HttpRequestStorage.DatabaseEntities.OrganizationRelationshipTypes.SingleOrDefault(x =>
-                    "Owner Organization".Equals(x.OrganizationRelationshipTypeName) && x.TenantID == currentPerson.TenantID);
+                HttpRequestStorage.DatabaseEntities.OrganizationRelationshipTypes.SingleOrDefault(x => x.IsPrimaryContact && x.TenantID == currentPerson.TenantID);
             var projectOwnerOrganizationsOld =
                 HttpRequestStorage.DatabaseEntities.ProjectOrganizations
                     .Where(x => x.OrganizationRelationshipTypeID ==

--- a/Source/ProjectFirma.Web/Views/Home/FeaturedProjects.cshtml
+++ b/Source/ProjectFirma.Web/Views/Home/FeaturedProjects.cshtml
@@ -45,7 +45,7 @@ Source code is available upon request via <support@sitkatech.com>.
     @* ReSharper disable once UnknownCssClass *@
     <div id="featuredProjectsCarousel" class="carousel slide" data-ride="carousel" data-interval="8000">
         <!-- Wrapper for slides -->
-        <div class="carousel-inner" role="listbox" style="height: 400px">
+        <div class="carousel-inner" role="listbox" style="height: 440px">
             @for (var index = 0; index < ViewDataTyped.FeaturedProjects.Count; ++index)
             {
                 var featuredProject = ViewDataTyped.FeaturedProjects[index];
@@ -72,7 +72,11 @@ Source code is available upon request via <support@sitkatech.com>.
                                         <td>@featuredProject.TaxonomyLeaf.TaxonomyLeafName</td>
                                     </tr>
                                     <tr>
-                                        <th>@FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabelPluralized()</th>
+                                        <th>@FieldDefinitionEnum.IsPrimaryContactOrganization.ToType().GetFieldDefinitionLabel()</th>
+                                        <td>@featuredProject.GetPrimaryContactOrganization().OrganizationName</td>
+                                    </tr>
+                                    <tr>
+                                        <th>Other @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabelPluralized()</th>
                                         <td>@featuredProject.GetProjectOrganizationNamesForFactSheet()</td>
                                     </tr>
                                     <tr>


### PR DESCRIPTION
Added Lead Implementer to features projects on home page. Also increased the height of the carousel so that "view more" shows up. Did not check all Tenants, but this works for PSP.

Also fixed potential bug with Funding Status custom results page for AA: was not using the IsPrimaryContact to find the organization relationship type for 'owner organization' and should have been.