### PR TITLE
Features/1942 improve classification detail page

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/ClassificationController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ClassificationController.cs
@@ -166,7 +166,7 @@ namespace ProjectFirma.Web.Controllers
             var currentPersonCanViewProposals = CurrentPerson.CanViewProposals();
 
             var projectMapCustomization = ProjectMapCustomization.CreateDefaultCustomization(associatedProjects, currentPersonCanViewProposals);
-            var projectLocationsLayerGeoJson = new LayerGeoJson($"{FieldDefinitionEnum.ProjectLocation.ToType().GetFieldDefinitionLabelPluralized()}", associatedProjects.MappedPointsToGeoJsonFeatureCollection(false, true), "red", 1, LayerInitialVisibility.Show);
+            var projectLocationsLayerGeoJson = new LayerGeoJson($"{FieldDefinitionEnum.ProjectLocation.ToType().GetFieldDefinitionLabelPluralized()}", associatedProjects.MappedPointsToGeoJsonFeatureCollection(true, false), "red", 1, LayerInitialVisibility.Show);
             var projectLocationsMapInitJson = new ProjectLocationsMapInitJson(projectLocationsLayerGeoJson,
                 projectMapCustomization, mapDivID)
             {

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectLocationControls/ProjectLocationsMap.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectLocationControls/ProjectLocationsMap.cshtml
@@ -33,12 +33,13 @@ Source code is available upon request via <support@sitkatech.com>.
 
     .mapLegendElement {
         display: inline-block;
-        margin-right: 10px;
+        margin-right: 13px;
     }
 
     .mapLegendIcon
     {
-        margin-bottom: -30px;
+        margin-bottom: -20px;
+        margin-right: 2px
     }
 
     .mapLegendElement .maki-marker
@@ -168,7 +169,7 @@ Source code is available upon request via <support@sitkatech.com>.
         var allLegendsHtml = "";
         for (var i = 0; i < markerColorTable.length; ++i)
         {
-            var currentLegendIcon = L.MakiMarkers.icon({ icon: "marker", color: markerColorTable[i].LegendColor, size: "m" }),
+            var currentLegendIcon = L.MakiMarkers.icon({ icon: "marker", color: markerColorTable[i].LegendColor, size: "s" }),
                 currentLegendAsHtml = currentLegendIcon.options.iconUrl;
             allLegendsHtml += "<div class=\"mapLegendElement\">" + "<img class='mapLegendIcon' src= '" + currentLegendAsHtml  + "'></img>" + markerColorTable[i].LegendText + "</div>";
         }

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectLocationControls/ProjectLocationsMap.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectLocationControls/ProjectLocationsMap.cshtml
@@ -81,6 +81,9 @@ Source code is available upon request via <support@sitkatech.com>.
         this.mapCustomizationObject = projectLocationsMapInitJson.ProjectMapCustomization;
         // draw the project locations
         this.addLocationLayers();
+
+        // prevent standard popup for lat/long when clicking on general map area (not features)
+        this.removeClickEventHandler();
     };
 
     ProjectFirmaMaps.Map.prototype.changeFilter = function(filterPropertyNameSelected, actualFilter)

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectLocationControls/ProjectMapPopup.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectLocationControls/ProjectMapPopup.cshtml
@@ -24,7 +24,7 @@
 @using ProjectFirma.Web.Models
 @inherits ProjectFirma.Web.Views.Shared.ProjectLocationControls.ProjectMapPopup
 <style>
-    .row {
+    .popupRow {
         margin-bottom: 5px;
         padding-left: 10px;
     }
@@ -60,7 +60,7 @@
     </style>
     <div style="width:@(ViewDataTyped.KeyPhoto != null ? "425px": "300px")">
         <div style="font-weight: bold; border-bottom: 1px solid lightgray; margin-bottom: 10px">@ViewDataTyped.DisplayName</div>
-        <div class="row">
+        <div class="row popupRow">
             @if (ViewDataTyped.KeyPhoto != null)
             {
                 <div class="col-xs-4 text-center" style="padding: 0 5px">
@@ -97,7 +97,7 @@
                 </dl>
             </div>
         </div>
-        <div class="row">
+        <div class="row popupRow">
             <div class="col-xs-12 text-center">
                 <span>
                     @ViewDataTyped.DetailLinkDescriptor


### PR DESCRIPTION
rework
- map popup when clicking on project simple location shows project name and links to fact sheet
- prevent standard lat/long popup when clicking general map area (not features) for all project location maps
- fixed css for ProjectMapPopup so it does not affect the rest of the page the map is on (prevents the weird line by the Overview tab reported by Liz from appearing)
- changed size of project location map legend icons to be small (instead of medium)