### PR TITLE
[projectfirma/#2047] Bug: Focus issue on fields with Help text

### DIFF
--- a/Source/ProjectFirma.Web/Common/LabelForExtensions.cs
+++ b/Source/ProjectFirma.Web/Common/LabelForExtensions.cs
@@ -193,9 +193,15 @@ namespace ProjectFirma.Web.Common
                 case DisplayStyle.HelpIconOnly:
                     return MvcHtmlString.Create(helpIconImgTag);
                 case DisplayStyle.HelpIconWithLabel:
+                    var labelWrapperTag = new TagBuilder("div");
                     var requiredAsterisk = BuildRequiredAsterisk(hasRequiredAttribute, labelTag);
-                    labelTag.InnerHtml = string.Format("{0}{1}{2}", helpIconImgTag, labelText, requiredAsterisk);
-                    return MvcHtmlString.Create(labelTag.ToString(TagRenderMode.Normal));
+
+                    labelTag.Attributes.Add("style", "display:inline;");
+                    labelTag.InnerHtml = string.Format("{0}{1}", labelText, requiredAsterisk);
+                   
+                    labelWrapperTag.AddCssClass("firma-label-wrapper");
+                    labelWrapperTag.InnerHtml = string.Format("{0}{1}", helpIconImgTag, labelTag.ToString(TagRenderMode.Normal));
+                    return MvcHtmlString.Create(labelWrapperTag.ToString(TagRenderMode.Normal));
                 default:
                     throw new ArgumentOutOfRangeException("displayStyle");
             }


### PR DESCRIPTION
* Moving the help icon out of the label
* Add wrapping element to the HelpIconWithLabel Display Style for the LabelWithFieldDefinitionForImpl method
* Adjusting the inline style for the label to "display:inline;" to format the help icon before the label text appropriately