### PR TITLE
[delta/#435] Add FundingSourceIDs to ProjectDto

### DIFF
--- a/Source/ProjectFirma.Api/Models/ProjectDto.cs
+++ b/Source/ProjectFirma.Api/Models/ProjectDto.cs
@@ -64,6 +64,11 @@ namespace ProjectFirma.Api.Models
             TargetedFundingLeveragedFunds = TargetedFunding - targetedFundingForFundingSources;
             SecuredFunding = securedFundingForFundingSources;
             TargetedFunding = targetedFundingForFundingSources;
+
+            var projectFundingSourceIDs = new List<int>();
+            projectFundingSourceIDs.AddRange(project.ProjectFundingSourceBudgets.Select(x => x.FundingSourceID));
+            projectFundingSourceIDs.AddRange(project.ProjectFundingSourceExpenditures.Select(x => x.FundingSourceID));
+            FundingSourceIDs = projectFundingSourceIDs;
         }
 
         public ProjectDto()
@@ -96,6 +101,8 @@ namespace ProjectFirma.Api.Models
 
         public decimal? EstimatedTotalCost { get; set; }
         public decimal? TotalExpenditures { get; set; }
+        public List<int> FundingSourceIDs { get; set; }
+
         public Feature LocationPointAsGeoJsonFeature { get; set; }
 
         public DateTime LastUpdatedDate { get; set; }


### PR DESCRIPTION
Add FundingSourceIDs to ProjectDto for all funding sources use in a project's budget or expenditures, so PS Info can know which (if any) NEP Awardee is associated with the project