### PR TITLE
[projectfirma/#2129] dropped column NoFundingSourceIdentifiedYet

### DIFF
--- a/Database/ReleaseScript/0403 - Insert ProjectNoFundingSourceIdentified rows for simple budget varies by year.sql
+++ b/Database/ReleaseScript/0403 - Insert ProjectNoFundingSourceIdentified rows for simple budget varies by year.sql
@@ -1,7 +1,14 @@
 insert into dbo.ProjectNoFundingSourceIdentified (ProjectID, TenantID, NoFundingSourceIdentifiedYet)
 select ProjectID, TenantID, NoFundingSourceIdentifiedYet
 from dbo.Project
-where NoFundingSourceIdentifiedYet is not null and TenantID not in (11, 12) and FundingTypeID = 1
+where NoFundingSourceIdentifiedYet is not null
 
-update dbo.Project set NoFundingSourceIdentifiedYet = null
-where NoFundingSourceIdentifiedYet is not null and TenantID not in (11, 12) and FundingTypeID = 1
+alter table dbo.Project drop column NoFundingSourceIdentifiedYet
+
+
+insert into dbo.ProjectNoFundingSourceIdentifiedUpdate (TenantID, ProjectUpdateBatchID, NoFundingSourceIdentifiedYet)
+select TenantID, ProjectUpdateBatchID, NoFundingSourceIdentifiedYet
+from dbo.ProjectUpdate
+where NoFundingSourceIdentifiedYet is not null
+
+alter table dbo.ProjectUpdate drop column NoFundingSourceIdentifiedYet

--- a/Database/Tables/dbo.Project.sql
+++ b/Database/Tables/dbo.Project.sql
@@ -30,7 +30,6 @@ CREATE TABLE [dbo].[Project](
 	[ReviewedByPersonID] [int] NULL,
 	[DefaultBoundingBox] [geometry] NULL,
 	[ExpendituresNote] [varchar](max) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
-	[NoFundingSourceIdentifiedYet] [money] NULL,
 	[ExpectedFundingUpdateNote] [varchar](500) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
 	[LastUpdatedDate] [datetime] NOT NULL,
 	[ProjectCategoryID] [int] NOT NULL,

--- a/Database/Tables/dbo.ProjectUpdate.sql
+++ b/Database/Tables/dbo.ProjectUpdate.sql
@@ -18,7 +18,6 @@ CREATE TABLE [dbo].[ProjectUpdate](
 	[EstimatedAnnualOperatingCostDeprecated] [decimal](18, 0) NULL,
 	[PrimaryContactPersonID] [int] NULL,
 	[FundingTypeID] [int] NULL,
-	[NoFundingSourceIdentifiedYet] [money] NULL,
  CONSTRAINT [PK_ProjectUpdate_ProjectUpdateID] PRIMARY KEY CLUSTERED 
 (
 	[ProjectUpdateID] ASC

--- a/Source/ProjectFirma.Web/Controllers/ProjectController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectController.cs
@@ -645,9 +645,35 @@ namespace ProjectFirma.Web.Controllers
             workSheets.Add(wsProjectFundingSourceExpenditures);
 
             var projectFundingSourceBudgetExcelSpec = new ProjectFundingSourceBudgetExcelSpec(fundingSourceCustomAttributeTypes, reportFinancialsByCostType);
-            // add ProjectFundingSourceBudgets and ProjectNoFundingSourceIdentifieds for "varies by year"
-            var projectBudgetFinancialsForExcels = projects.Where(p => p.FundingTypeID == FundingType.BudgetVariesByYear.FundingTypeID).SelectMany(p => p.ProjectFundingSourceBudgets.Select(y => new ProjectBudgetFinancialsForExcel(y, reportFinancialsByCostType, null))).ToList();
-            projectBudgetFinancialsForExcels.AddRange(projects.SelectMany(p => p.ProjectNoFundingSourceIdentifieds.Select(y => new ProjectBudgetFinancialsForExcel(y))).ToList());
+            var projectBudgetFinancialsForExcels = new List<ProjectBudgetFinancialsForExcel>();
+            // add ProjectFundingSourceBudgets and ProjectNoFundingSourceIdentifieds for "varies by year" for Tenants that use Annual Budget by Cost Type or Annual Budget (current no tenants use this, but adding for future support)
+            if (reportFinancialsByCostType || budgetType == BudgetType.AnnualBudget)
+            {
+                projectBudgetFinancialsForExcels = projects.Where(p => p.FundingTypeID == FundingType.BudgetVariesByYear.FundingTypeID).SelectMany(p => p.ProjectFundingSourceBudgets.Select(y => new ProjectBudgetFinancialsForExcel(y, reportFinancialsByCostType, null))).ToList();
+                projectBudgetFinancialsForExcels.AddRange(projects.Where(p => p.FundingTypeID == FundingType.BudgetVariesByYear.FundingTypeID).SelectMany(p => p.ProjectNoFundingSourceIdentifieds.Select(y => new ProjectBudgetFinancialsForExcel(y, null))).ToList());
+            }
+            else
+            {
+                // add ProjectFundingSourceBudgets and ProjectNoFundingSourceIdentifieds for "varies by year" for Tenants that use Simple Budget. Need to add one row per year of the project, because current CalendarYear not set for these ProjectFundingSourceBudgets
+                projectBudgetFinancialsForExcels.AddRange(projects.Where(p => p.FundingTypeID == FundingType.BudgetVariesByYear.FundingTypeID).SelectMany(p =>
+                {
+                    var budgetFinancialsForExcels = new List<ProjectBudgetFinancialsForExcel>();
+                    for (var i = p.ImplementationStartYear ?? DateTime.Now.Year; i <= (p.CompletionYear ?? DateTime.Now.Year); i++)
+                    {
+                        budgetFinancialsForExcels.AddRange(p.ProjectFundingSourceBudgets.Select(pfsb => new ProjectBudgetFinancialsForExcel(pfsb, reportFinancialsByCostType, i)).ToList());
+                    }
+                    return budgetFinancialsForExcels;
+                }).ToList());
+                projectBudgetFinancialsForExcels.AddRange(projects.Where(p => p.FundingTypeID == FundingType.BudgetVariesByYear.FundingTypeID).SelectMany(p => p.ProjectNoFundingSourceIdentifieds.SelectMany(y =>
+                {
+                    var budgetFinancialsForExcels = new List<ProjectBudgetFinancialsForExcel>();
+                    for (var i = p.ImplementationStartYear ?? DateTime.Now.Year; i <= (p.CompletionYear ?? DateTime.Now.Year); i++)
+                    {
+                        budgetFinancialsForExcels.Add(new ProjectBudgetFinancialsForExcel(y, i));
+                    }
+                    return budgetFinancialsForExcels;
+                })).ToList());
+            }
             // add ProjectFundingSourceBudgets for "same each year"
             projectBudgetFinancialsForExcels.AddRange(projects.Where(p => p.FundingTypeID == FundingType.BudgetSameEachYear.FundingTypeID).SelectMany(p =>
             {
@@ -659,15 +685,15 @@ namespace ProjectFirma.Web.Controllers
                 return budgetFinancialsForExcels;
             }).ToList());
             // add no funding source identified for "same each year"
-            projectBudgetFinancialsForExcels.AddRange(projects.Where(p => p.FundingTypeID == FundingType.BudgetSameEachYear.FundingTypeID).SelectMany(p =>
+            projectBudgetFinancialsForExcels.AddRange(projects.Where(p => p.FundingTypeID == FundingType.BudgetSameEachYear.FundingTypeID).SelectMany(p => p.ProjectNoFundingSourceIdentifieds.SelectMany(y =>
             {
                 var budgetFinancialsForExcels = new List<ProjectBudgetFinancialsForExcel>();
                 for (var i = p.ImplementationStartYear ?? DateTime.Now.Year; i <= (p.CompletionYear ?? DateTime.Now.Year); i++)
                 {
-                    budgetFinancialsForExcels.Add(new ProjectBudgetFinancialsForExcel(p, i));
+                    budgetFinancialsForExcels.Add(new ProjectBudgetFinancialsForExcel(y, i));
                 }
                 return budgetFinancialsForExcels;
-            }).ToList());
+            })).ToList());
             projectBudgetFinancialsForExcels = projectBudgetFinancialsForExcels.OrderBy(x => x.Project.ProjectID)
                 .ThenBy(x => x.FundingSource).ThenBy(x => x.CalendarYear).ToList();
             var wsProjectFundingSourceBudgets = ExcelWorkbookSheetDescriptorFactory.MakeWorksheet("Budgets", projectFundingSourceBudgetExcelSpec, projectBudgetFinancialsForExcels);

--- a/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
@@ -844,7 +844,6 @@ namespace ProjectFirma.Web.Controllers
             ProjectNoFundingSourceIdentifiedUpdateModelExtensions.CreateFromProject(projectUpdateBatch);
             // Need to revert project-level budget data too
             projectUpdateBatch.ProjectUpdate.FundingTypeID = project.FundingTypeID;
-            projectUpdateBatch.ProjectUpdate.NoFundingSourceIdentifiedYet = project.NoFundingSourceIdentifiedYet;
 
             projectUpdateBatch.TickleLastUpdateDate(CurrentFirmaSession);
             SetMessageForDisplay($"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} Budget successfully reverted.");
@@ -961,14 +960,7 @@ namespace ProjectFirma.Web.Controllers
             ProjectFundingSourceBudgetUpdateModelExtensions.CreateFromProject(projectUpdateBatch);
             // Need to revert project-level budget data too
             projectUpdateBatch.ProjectUpdate.FundingTypeID = project.FundingTypeID;
-            if (project.FundingTypeID == FundingType.BudgetSameEachYear.FundingTypeID)
-            {
-                projectUpdateBatch.ProjectUpdate.NoFundingSourceIdentifiedYet = project.NoFundingSourceIdentifiedYet;
-            }
-            else
-            {
-                ProjectNoFundingSourceIdentifiedUpdateModelExtensions.CreateFromProject(projectUpdateBatch);
-            }
+            ProjectNoFundingSourceIdentifiedUpdateModelExtensions.CreateFromProject(projectUpdateBatch);
             projectUpdateBatch.TickleLastUpdateDate(CurrentFirmaSession);
             SetMessageForDisplay($"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} Budget successfully reverted.");
             return new ModalDialogFormJsonResult();
@@ -2747,9 +2739,9 @@ namespace ProjectFirma.Web.Controllers
             var projectUpdateBatch = GetLatestNotApprovedProjectUpdateBatchAndThrowIfNoneFound(project, $"There is no current {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} Update for {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} {project.GetDisplayName()}");
             var projectFundingSourceBudgetsOriginal = new List<IFundingSourceBudgetAmount>(project.ProjectFundingSourceBudgets.ToList());
             var projectFundingSourceBudgetsUpdated = new List<IFundingSourceBudgetAmount>(projectUpdateBatch.ProjectFundingSourceBudgetUpdates.ToList());
-            var originalHtml = GeneratePartialViewForOriginalFundingRequests(project.FundingTypeID, project.FundingType?.FundingTypeDisplayName, projectFundingSourceBudgetsOriginal, projectFundingSourceBudgetsUpdated, project.NoFundingSourceIdentifiedYet, project.PlanningDesignStartYear, project.CompletionYear, project.ExpectedFundingUpdateNote);
+            var originalHtml = GeneratePartialViewForOriginalFundingRequests(project.FundingTypeID, project.FundingType?.FundingTypeDisplayName, projectFundingSourceBudgetsOriginal, projectFundingSourceBudgetsUpdated, project.GetNoFundingSourceIdentifiedAmount(), project.PlanningDesignStartYear, project.CompletionYear, project.ExpectedFundingUpdateNote);
             var updatedHtml = GeneratePartialViewForModifiedFundingRequests(projectUpdateBatch.ProjectUpdate.FundingTypeID, projectUpdateBatch.ProjectUpdate.FundingType?.FundingTypeDisplayName, projectFundingSourceBudgetsOriginal, projectFundingSourceBudgetsUpdated, 
-                projectUpdateBatch.ProjectUpdate.NoFundingSourceIdentifiedYet, projectUpdateBatch.ProjectUpdate.PlanningDesignStartYear, projectUpdateBatch.ProjectUpdate.CompletionYear, projectUpdateBatch.ExpectedFundingUpdateNote);
+                projectUpdateBatch.ProjectUpdate.GetNoFundingSourceIdentifiedAmount(), projectUpdateBatch.ProjectUpdate.PlanningDesignStartYear, projectUpdateBatch.ProjectUpdate.CompletionYear, projectUpdateBatch.ExpectedFundingUpdateNote);
             return new HtmlDiffContainer(originalHtml, updatedHtml);
         }
 

--- a/Source/ProjectFirma.Web/Models/ProjectFundingSourceBudgetUpdateModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectFundingSourceBudgetUpdateModelExtensions.cs
@@ -46,7 +46,6 @@ namespace ProjectFirma.Web.Models
         public static void CommitChangesToProject(ProjectUpdateBatch projectUpdateBatch, DatabaseEntities databaseEntities)
         {
             var project = projectUpdateBatch.Project;
-            project.NoFundingSourceIdentifiedYet = projectUpdateBatch.ProjectUpdate.NoFundingSourceIdentifiedYet;
             project.ExpectedFundingUpdateNote = projectUpdateBatch.ExpectedFundingUpdateNote;
             project.FundingTypeID = projectUpdateBatch.ProjectUpdate.FundingTypeID;
             var projectFundingSourceExpectedFundingFromProjectUpdate = projectUpdateBatch

--- a/Source/ProjectFirma.Web/Models/ProjectUpdateBatchModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectUpdateBatchModelExtensions.cs
@@ -87,11 +87,7 @@ namespace ProjectFirma.Web.Models
 
             // Expected Funding
             ProjectFundingSourceBudgetUpdateModelExtensions.CreateFromProject(projectUpdateBatch);
-
-            if (project.FundingType == FundingType.BudgetVariesByYear)
-            {
-                ProjectNoFundingSourceIdentifiedUpdateModelExtensions.CreateFromProject(projectUpdateBatch);
-            }
+            ProjectNoFundingSourceIdentifiedUpdateModelExtensions.CreateFromProject(projectUpdateBatch);
 
             // expected performance measures
             PerformanceMeasureExpectedUpdateModelExtensions.CreateFromProject(projectUpdateBatch);

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/ExpectedFundingViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/ExpectedFundingViewModel.cs
@@ -52,9 +52,7 @@ namespace ProjectFirma.Web.Views.ProjectCreate
 
         public ExpectedFundingViewModel(ProjectFirmaModels.Models.Project project)
         {
-            NoFundingSourceIdentifiedYet = project.FundingType == FundingType.BudgetVariesByYear
-                ? project.ProjectNoFundingSourceIdentifieds.FirstOrDefault()?.NoFundingSourceIdentifiedYet
-                : project.NoFundingSourceIdentifiedYet;
+            NoFundingSourceIdentifiedYet = project.ProjectNoFundingSourceIdentifieds.FirstOrDefault()?.NoFundingSourceIdentifiedYet;
             var projectFundingSourceBudgets = project.ProjectFundingSourceBudgets.ToList();
             ViewModelForAngular = new ViewModelForAngularEditor(project.FundingTypeID ?? 0, projectFundingSourceBudgets, NoFundingSourceIdentifiedYet);
             Comments = project.BudgetComment;
@@ -85,35 +83,31 @@ namespace ProjectFirma.Web.Views.ProjectCreate
         public void UpdateModel(ProjectFirmaModels.Models.Project project,
             List<ProjectFirmaModels.Models.ProjectFundingSourceBudget> currentProjectFundingSourceBudgets,
             IList<ProjectFirmaModels.Models.ProjectFundingSourceBudget> allProjectFundingSourceBudgets,
-            List<ProjectFirmaModels.Models.ProjectNoFundingSourceIdentified> currentProjectNoFundingSourceIdentifieds,
-            IList<ProjectFirmaModels.Models.ProjectNoFundingSourceIdentified> allProjectNoFundingSourceIdentifieds)
+            List<ProjectNoFundingSourceIdentified> currentProjectNoFundingSourceIdentifieds,
+            IList<ProjectNoFundingSourceIdentified> allProjectNoFundingSourceIdentifieds)
         {
             if (ViewModelForAngular.FundingTypeID > 0)
             {
                 project.FundingTypeID = ViewModelForAngular.FundingTypeID;
             }
 
-            if (FundingType.BudgetVariesByYear.FundingTypeID == ViewModelForAngular.FundingTypeID)
+            
+            var projectNoFundingSourceIdentifiedsUpdated = new List<ProjectNoFundingSourceIdentified>();
+            if (ViewModelForAngular?.NoFundingSourceIdentifiedYet != null)
             {
-                var projectProjectNoFundingSourceIdentifiedsUpdated = new List<ProjectFirmaModels.Models.ProjectNoFundingSourceIdentified>();
-                if (ViewModelForAngular?.NoFundingSourceIdentifiedYet != null)
-                {
-                    // Completely rebuild the list
-                    projectProjectNoFundingSourceIdentifiedsUpdated.Add(new ProjectNoFundingSourceIdentified(project.ProjectID) { NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet });
-                }
+                // Completely rebuild the list
+                projectNoFundingSourceIdentifiedsUpdated.Add(new ProjectNoFundingSourceIdentified(project.ProjectID) { NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet });
+            }
 
-                currentProjectNoFundingSourceIdentifieds.Merge(projectProjectNoFundingSourceIdentifiedsUpdated,
-                    allProjectNoFundingSourceIdentifieds,
-                    (x, y) => x.ProjectID == y.ProjectID,
-                    (x, y) =>
-                    {
-                        x.NoFundingSourceIdentifiedYet = y.NoFundingSourceIdentifiedYet;
-                    }, HttpRequestStorage.DatabaseEntities);
-            }
-            else
-            {
-                project.NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet;
-            }
+            currentProjectNoFundingSourceIdentifieds.Merge(projectNoFundingSourceIdentifiedsUpdated,
+                allProjectNoFundingSourceIdentifieds,
+                (x, y) => x.ProjectID == y.ProjectID && x.CalendarYear == y.CalendarYear,
+                (x, y) =>
+                {
+                    x.NoFundingSourceIdentifiedYet = y.NoFundingSourceIdentifiedYet;
+                }, HttpRequestStorage.DatabaseEntities);
+            
+
 
             var projectFundingSourceBudgetsUpdated = new List<ProjectFirmaModels.Models.ProjectFundingSourceBudget>();
             if (ViewModelForAngular?.ProjectFundingSourceBudgets != null)

--- a/Source/ProjectFirma.Web/Views/ProjectFundingSourceBudget/EditProjectFundingSourceBudgetByCostTypeViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectFundingSourceBudget/EditProjectFundingSourceBudgetByCostTypeViewModel.cs
@@ -79,7 +79,7 @@ namespace ProjectFirma.Web.Views.ProjectFundingSourceBudget
 
                     case FundingTypeEnum.BudgetSameEachYear:
                         ProjectFundingSourceBudgets = ProjectFundingSourceBudgetsByCostTypeBulk.MakeFromListByCostType(project, new List<int>());
-                        NoFundingSourceIdentifiedYet = project.NoFundingSourceIdentifiedYet;
+                        NoFundingSourceIdentifiedYet = project.ProjectNoFundingSourceIdentifieds.FirstOrDefault()?.NoFundingSourceIdentifiedYet;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();
@@ -110,10 +110,13 @@ namespace ProjectFirma.Web.Views.ProjectFundingSourceBudget
                 (x, y) => x.ProjectID == y.ProjectID && x.FundingSourceID == y.FundingSourceID && x.CostTypeID == y.CostTypeID && x.CalendarYear == y.CalendarYear,
                 (x, y) => x.SetSecuredAndTargetedAmounts(y.SecuredAmount, y.TargetedAmount), databaseEntities);
 
-            // set if funding type is "Same Each Year", null out otherwise
-            project.NoFundingSourceIdentifiedYet = NoFundingSourceIdentifiedYet;
             var projectNoFundingSourceAmountsUpdated = new List<ProjectNoFundingSourceIdentified>();
-            if (NoFundingSourceAmounts != null)
+            if (FundingTypeID == FundingType.BudgetSameEachYear.FundingTypeID && NoFundingSourceIdentifiedYet != null)
+            {
+                // Completely rebuild the list
+                projectNoFundingSourceAmountsUpdated.Add(new ProjectNoFundingSourceIdentified(project.ProjectID) { NoFundingSourceIdentifiedYet = NoFundingSourceIdentifiedYet });
+            }
+            else if (FundingTypeID == FundingType.BudgetVariesByYear.FundingTypeID && NoFundingSourceAmounts != null)
             {
                 // Completely rebuild the list
                 projectNoFundingSourceAmountsUpdated = NoFundingSourceAmounts.Where(x => x.MonetaryAmount.HasValue)

--- a/Source/ProjectFirma.Web/Views/ProjectFundingSourceBudget/EditProjectFundingSourceBudgetViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectFundingSourceBudget/EditProjectFundingSourceBudgetViewModel.cs
@@ -50,9 +50,7 @@ namespace ProjectFirma.Web.Views.ProjectFundingSourceBudget
             List<ProjectFirmaModels.Models.ProjectFundingSourceBudget> projectFundingSourceBudgets)
         {
             var fundingTypeID = project.FundingTypeID ?? 0;
-            NoFundingSourceIdentifiedYet = project.FundingType == FundingType.BudgetVariesByYear
-                ? project.ProjectNoFundingSourceIdentifieds.FirstOrDefault()?.NoFundingSourceIdentifiedYet
-                : project.NoFundingSourceIdentifiedYet;
+            NoFundingSourceIdentifiedYet = project.ProjectNoFundingSourceIdentifieds.FirstOrDefault()?.NoFundingSourceIdentifiedYet;
             ViewModelForAngular = new ViewModelForAngularEditor(fundingTypeID, projectFundingSourceBudgets, NoFundingSourceIdentifiedYet);
 
         }
@@ -86,27 +84,21 @@ namespace ProjectFirma.Web.Views.ProjectFundingSourceBudget
             IList<ProjectFirmaModels.Models.ProjectNoFundingSourceIdentified> allProjectNoFundingSourceIdentifieds)
         {
             project.FundingTypeID = ViewModelForAngular.FundingTypeID;
-            if (FundingType.BudgetVariesByYear.FundingTypeID == ViewModelForAngular.FundingTypeID)
+            
+            var projectProjectNoFundingSourceIdentifiedsUpdated = new List<ProjectFirmaModels.Models.ProjectNoFundingSourceIdentified>();
+            if (ViewModelForAngular?.NoFundingSourceIdentifiedYet != null)
             {
-                var projectProjectNoFundingSourceIdentifiedsUpdated = new List<ProjectFirmaModels.Models.ProjectNoFundingSourceIdentified>();
-                if (ViewModelForAngular?.NoFundingSourceIdentifiedYet != null)
-                {
-                    // Completely rebuild the list
-                    projectProjectNoFundingSourceIdentifiedsUpdated.Add(new ProjectNoFundingSourceIdentified(project.ProjectID) {NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet });
-                }
+                // Completely rebuild the list
+                projectProjectNoFundingSourceIdentifiedsUpdated.Add(new ProjectNoFundingSourceIdentified(project.ProjectID) {NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet });
+            }
 
-                currentProjectNoFundingSourceIdentifieds.Merge(projectProjectNoFundingSourceIdentifiedsUpdated,
-                    allProjectNoFundingSourceIdentifieds,
-                    (x, y) => x.ProjectID == y.ProjectID,
-                    (x, y) =>
-                    {
-                        x.NoFundingSourceIdentifiedYet = y.NoFundingSourceIdentifiedYet;
-                    }, HttpRequestStorage.DatabaseEntities);
-            }
-            else
-            {
-                project.NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet;
-            }
+            currentProjectNoFundingSourceIdentifieds.Merge(projectProjectNoFundingSourceIdentifiedsUpdated,
+                allProjectNoFundingSourceIdentifieds,
+                (x, y) => x.ProjectID == y.ProjectID && x.CalendarYear == y.CalendarYear,
+                (x, y) =>
+                {
+                    x.NoFundingSourceIdentifiedYet = y.NoFundingSourceIdentifiedYet;
+                }, HttpRequestStorage.DatabaseEntities);
 
             var projectFundingSourceBudgetsUpdated = new List<ProjectFirmaModels.Models.ProjectFundingSourceBudget>();
             if (ViewModelForAngular?.ProjectFundingSourceBudgets != null)

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpectedFundingViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ExpectedFundingViewModel.cs
@@ -57,9 +57,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
         public ExpectedFundingViewModel(ProjectUpdateBatch projectUpdateBatch, List<ProjectFundingSourceBudgetUpdate> projectFundingSourceBudgetUpdates,
             string comments)
         {
-            NoFundingSourceIdentifiedYet = projectUpdateBatch.ProjectUpdate.FundingType == FundingType.BudgetVariesByYear
-                ? projectUpdateBatch.ProjectNoFundingSourceIdentifiedUpdates.FirstOrDefault()?.NoFundingSourceIdentifiedYet
-                : projectUpdateBatch.ProjectUpdate.NoFundingSourceIdentifiedYet;
+            NoFundingSourceIdentifiedYet = projectUpdateBatch.ProjectNoFundingSourceIdentifiedUpdates.FirstOrDefault()?.NoFundingSourceIdentifiedYet;
             Comments = comments;
             ExpectedFundingUpdateNote = projectUpdateBatch.ExpectedFundingUpdateNote;
             ViewModelForAngular = new ViewModelForAngularEditor(projectUpdateBatch.ProjectUpdate.FundingTypeID ?? 0, projectFundingSourceBudgetUpdates, NoFundingSourceIdentifiedYet);
@@ -98,29 +96,20 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
                 projectUpdateBatch.ProjectUpdate.FundingTypeID = ViewModelForAngular.FundingTypeID;
             }
 
-            if (FundingType.BudgetVariesByYear.FundingTypeID == ViewModelForAngular.FundingTypeID)
+            var projectProjectNoFundingSourceIdentifiedsUpdated = new List<ProjectFirmaModels.Models.ProjectNoFundingSourceIdentifiedUpdate>();
+            if (ViewModelForAngular?.NoFundingSourceIdentifiedYet != null)
             {
-                var projectProjectNoFundingSourceIdentifiedsUpdated = new List<ProjectFirmaModels.Models.ProjectNoFundingSourceIdentifiedUpdate>();
-                if (ViewModelForAngular?.NoFundingSourceIdentifiedYet != null)
+                // Completely rebuild the list
+                projectProjectNoFundingSourceIdentifiedsUpdated.Add(new ProjectNoFundingSourceIdentifiedUpdate(projectUpdateBatch.ProjectUpdateBatchID) { NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet });
+            }
+            currentProjectNoFundingSourceIdentifiedUpdates.Merge(projectProjectNoFundingSourceIdentifiedsUpdated,
+                allProjectNoFundingSourceIdentifiedUpdates,
+                (x, y) => x.ProjectUpdateBatchID == y.ProjectUpdateBatchID && x.CalendarYear == y.CalendarYear,
+                (x, y) =>
                 {
-                    // Completely rebuild the list
-                    projectProjectNoFundingSourceIdentifiedsUpdated.Add(new ProjectNoFundingSourceIdentifiedUpdate(projectUpdateBatch.ProjectUpdateBatchID) { NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet });
-                }
+                    x.NoFundingSourceIdentifiedYet = y.NoFundingSourceIdentifiedYet;
+                }, HttpRequestStorage.DatabaseEntities);
             
-                currentProjectNoFundingSourceIdentifiedUpdates.Merge(projectProjectNoFundingSourceIdentifiedsUpdated,
-                    allProjectNoFundingSourceIdentifiedUpdates,
-                    (x, y) => x.ProjectUpdateBatchID == y.ProjectUpdateBatchID,
-                    (x, y) =>
-                    {
-                        x.NoFundingSourceIdentifiedYet = y.NoFundingSourceIdentifiedYet;
-                    }, HttpRequestStorage.DatabaseEntities);
-            }
-            else
-            {
-                projectUpdateBatch.ProjectUpdate.NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet;
-            }
-
-            projectUpdateBatch.ProjectUpdate.NoFundingSourceIdentifiedYet = ViewModelForAngular.NoFundingSourceIdentifiedYet;
             projectUpdateBatch.ExpectedFundingUpdateNote = ExpectedFundingUpdateNote;
             var projectFundingSourceBudgetUpdatesUpdated = new List<ProjectFundingSourceBudgetUpdate>();
             if (ViewModelForAngular.ProjectFundingSourceBudgetUpdateSimples != null)

--- a/Source/ProjectFirmaModels/Models/Generated/Project.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/Project.Binding.cs
@@ -57,7 +57,7 @@ namespace ProjectFirmaModels.Models
         /// <summary>
         /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
         /// </summary>
-        public Project(int projectID, int taxonomyLeafID, int projectStageID, string projectName, string projectDescription, int? implementationStartYear, int? completionYear, decimal? estimatedTotalCostDeprecated, DbGeometry projectLocationPoint, string performanceMeasureActualYearsExemptionExplanation, bool isFeatured, string projectLocationNotes, int? planningDesignStartYear, int projectLocationSimpleTypeID, decimal? estimatedAnnualOperatingCostDeprecated, int? fundingTypeID, int? primaryContactPersonID, int projectApprovalStatusID, int? proposingPersonID, DateTime? proposingDate, string performanceMeasureNotes, DateTime? submissionDate, DateTime? approvalDate, int? reviewedByPersonID, DbGeometry defaultBoundingBox, string expendituresNote, decimal? noFundingSourceIdentifiedYet, string expectedFundingUpdateNote, DateTime lastUpdatedDate, int projectCategoryID, string basicsComment, string customAttributesComment, string locationSimpleComment, string locationDetailedComment, string organizationsComment, string contactsComment, string expectedAccomplishmentsComment, string reportedAccomplishmentsComment, string budgetComment, string expendituresComment, string proposalClassificationsComment, string attachmentsNotesComment, string photosComment) : this()
+        public Project(int projectID, int taxonomyLeafID, int projectStageID, string projectName, string projectDescription, int? implementationStartYear, int? completionYear, decimal? estimatedTotalCostDeprecated, DbGeometry projectLocationPoint, string performanceMeasureActualYearsExemptionExplanation, bool isFeatured, string projectLocationNotes, int? planningDesignStartYear, int projectLocationSimpleTypeID, decimal? estimatedAnnualOperatingCostDeprecated, int? fundingTypeID, int? primaryContactPersonID, int projectApprovalStatusID, int? proposingPersonID, DateTime? proposingDate, string performanceMeasureNotes, DateTime? submissionDate, DateTime? approvalDate, int? reviewedByPersonID, DbGeometry defaultBoundingBox, string expendituresNote, string expectedFundingUpdateNote, DateTime lastUpdatedDate, int projectCategoryID, string basicsComment, string customAttributesComment, string locationSimpleComment, string locationDetailedComment, string organizationsComment, string contactsComment, string expectedAccomplishmentsComment, string reportedAccomplishmentsComment, string budgetComment, string expendituresComment, string proposalClassificationsComment, string attachmentsNotesComment, string photosComment) : this()
         {
             this.ProjectID = projectID;
             this.TaxonomyLeafID = taxonomyLeafID;
@@ -85,7 +85,6 @@ namespace ProjectFirmaModels.Models
             this.ReviewedByPersonID = reviewedByPersonID;
             this.DefaultBoundingBox = defaultBoundingBox;
             this.ExpendituresNote = expendituresNote;
-            this.NoFundingSourceIdentifiedYet = noFundingSourceIdentifiedYet;
             this.ExpectedFundingUpdateNote = expectedFundingUpdateNote;
             this.LastUpdatedDate = lastUpdatedDate;
             this.ProjectCategoryID = projectCategoryID;
@@ -357,7 +356,6 @@ namespace ProjectFirmaModels.Models
         public int? ReviewedByPersonID { get; set; }
         public DbGeometry DefaultBoundingBox { get; set; }
         public string ExpendituresNote { get; set; }
-        public decimal? NoFundingSourceIdentifiedYet { get; set; }
         public string ExpectedFundingUpdateNote { get; set; }
         public DateTime LastUpdatedDate { get; set; }
         public int ProjectCategoryID { get; set; }

--- a/Source/ProjectFirmaModels/Models/Generated/ProjectConfiguration.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/ProjectConfiguration.Binding.cs
@@ -42,7 +42,6 @@ namespace ProjectFirmaModels.Models
             Property(x => x.ReviewedByPersonID).HasColumnName(@"ReviewedByPersonID").HasColumnType("int").IsOptional();
             Property(x => x.DefaultBoundingBox).HasColumnName(@"DefaultBoundingBox").HasColumnType("geometry").IsOptional();
             Property(x => x.ExpendituresNote).HasColumnName(@"ExpendituresNote").HasColumnType("varchar").IsOptional();
-            Property(x => x.NoFundingSourceIdentifiedYet).HasColumnName(@"NoFundingSourceIdentifiedYet").HasColumnType("money").IsOptional().HasPrecision(19,4);
             Property(x => x.ExpectedFundingUpdateNote).HasColumnName(@"ExpectedFundingUpdateNote").HasColumnType("varchar").IsOptional().IsUnicode(false).HasMaxLength(500);
             Property(x => x.LastUpdatedDate).HasColumnName(@"LastUpdatedDate").HasColumnType("datetime").IsRequired();
             Property(x => x.ProjectCategoryID).HasColumnName(@"ProjectCategoryID").HasColumnType("int").IsRequired();

--- a/Source/ProjectFirmaModels/Models/Generated/ProjectUpdate.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/ProjectUpdate.Binding.cs
@@ -30,7 +30,7 @@ namespace ProjectFirmaModels.Models
         /// <summary>
         /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
         /// </summary>
-        public ProjectUpdate(int projectUpdateID, int projectUpdateBatchID, int projectStageID, string projectDescription, int? implementationStartYear, int? completionYear, decimal? estimatedTotalCostDeprecated, DbGeometry projectLocationPoint, string projectLocationNotes, int? planningDesignStartYear, int projectLocationSimpleTypeID, decimal? estimatedAnnualOperatingCostDeprecated, int? primaryContactPersonID, int? fundingTypeID, decimal? noFundingSourceIdentifiedYet) : this()
+        public ProjectUpdate(int projectUpdateID, int projectUpdateBatchID, int projectStageID, string projectDescription, int? implementationStartYear, int? completionYear, decimal? estimatedTotalCostDeprecated, DbGeometry projectLocationPoint, string projectLocationNotes, int? planningDesignStartYear, int projectLocationSimpleTypeID, decimal? estimatedAnnualOperatingCostDeprecated, int? primaryContactPersonID, int? fundingTypeID) : this()
         {
             this.ProjectUpdateID = projectUpdateID;
             this.ProjectUpdateBatchID = projectUpdateBatchID;
@@ -46,7 +46,6 @@ namespace ProjectFirmaModels.Models
             this.EstimatedAnnualOperatingCostDeprecated = estimatedAnnualOperatingCostDeprecated;
             this.PrimaryContactPersonID = primaryContactPersonID;
             this.FundingTypeID = fundingTypeID;
-            this.NoFundingSourceIdentifiedYet = noFundingSourceIdentifiedYet;
         }
 
         /// <summary>
@@ -133,7 +132,6 @@ namespace ProjectFirmaModels.Models
         public decimal? EstimatedAnnualOperatingCostDeprecated { get; set; }
         public int? PrimaryContactPersonID { get; set; }
         public int? FundingTypeID { get; set; }
-        public decimal? NoFundingSourceIdentifiedYet { get; set; }
         [NotMapped]
         public int PrimaryKey { get { return ProjectUpdateID; } set { ProjectUpdateID = value; } }
 

--- a/Source/ProjectFirmaModels/Models/Generated/ProjectUpdateConfiguration.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/ProjectUpdateConfiguration.Binding.cs
@@ -30,7 +30,6 @@ namespace ProjectFirmaModels.Models
             Property(x => x.EstimatedAnnualOperatingCostDeprecated).HasColumnName(@"EstimatedAnnualOperatingCostDeprecated").HasColumnType("decimal").IsOptional();
             Property(x => x.PrimaryContactPersonID).HasColumnName(@"PrimaryContactPersonID").HasColumnType("int").IsOptional();
             Property(x => x.FundingTypeID).HasColumnName(@"FundingTypeID").HasColumnType("int").IsOptional();
-            Property(x => x.NoFundingSourceIdentifiedYet).HasColumnName(@"NoFundingSourceIdentifiedYet").HasColumnType("money").IsOptional().HasPrecision(19,4);
 
             // Foreign keys
             HasRequired(a => a.ProjectUpdateBatch).WithMany(b => b.ProjectUpdates).HasForeignKey(c => c.ProjectUpdateBatchID).WillCascadeOnDelete(false); // FK_ProjectUpdate_ProjectUpdateBatch_ProjectUpdateBatchID

--- a/Source/ProjectFirmaModels/Models/Project.cs
+++ b/Source/ProjectFirmaModels/Models/Project.cs
@@ -69,11 +69,7 @@ namespace ProjectFirmaModels.Models
 
         public decimal? GetNoFundingSourceIdentifiedAmount()
         {
-            if (FundingType == FundingType.BudgetVariesByYear)
-            {
-                return ProjectNoFundingSourceIdentifieds.Sum(x => x.NoFundingSourceIdentifiedYet.GetValueOrDefault());
-            }
-            return NoFundingSourceIdentifiedYet;
+            return ProjectNoFundingSourceIdentifieds.Sum(x => x.NoFundingSourceIdentifiedYet.GetValueOrDefault());
         }
 
         public decimal? GetEstimatedTotalRegardlessOfFundingType()

--- a/Source/ProjectFirmaModels/Models/ProjectBudgetFinancialsForExcel.cs
+++ b/Source/ProjectFirmaModels/Models/ProjectBudgetFinancialsForExcel.cs
@@ -48,18 +48,12 @@ namespace ProjectFirmaModels.Models
             }
         }
 
-        public ProjectBudgetFinancialsForExcel(ProjectNoFundingSourceIdentified projectNoFundingSourceIdentified)
+        public ProjectBudgetFinancialsForExcel(ProjectNoFundingSourceIdentified projectNoFundingSourceIdentified, int? calendarYear)
         {
             Project = projectNoFundingSourceIdentified.Project;
             NoFundingSourceIdentifiedAmount = projectNoFundingSourceIdentified.NoFundingSourceIdentifiedYet;
-            CalendarYear = projectNoFundingSourceIdentified.CalendarYear;
+            CalendarYear = calendarYear ?? projectNoFundingSourceIdentified.CalendarYear;
         }
 
-        public ProjectBudgetFinancialsForExcel(Project project, int calendarYear)
-        {
-            Project = project;
-            CalendarYear = calendarYear;
-            NoFundingSourceIdentifiedAmount = project.NoFundingSourceIdentifiedYet;
-        }
     }
 }

--- a/Source/ProjectFirmaModels/Models/ProjectUpdate.cs
+++ b/Source/ProjectFirmaModels/Models/ProjectUpdate.cs
@@ -48,11 +48,7 @@ namespace ProjectFirmaModels.Models
 
         public decimal? GetNoFundingSourceIdentifiedAmount()
         {
-            if (FundingType == FundingType.BudgetVariesByYear)
-            {
-                return ProjectUpdateBatch.ProjectNoFundingSourceIdentifiedUpdates.Sum(x => x.NoFundingSourceIdentifiedYet.GetValueOrDefault());
-            }
-            return NoFundingSourceIdentifiedYet;
+            return ProjectUpdateBatch.ProjectNoFundingSourceIdentifiedUpdates.Sum(x => x.NoFundingSourceIdentifiedYet.GetValueOrDefault());
         }
 
         public decimal? GetEstimatedTotalRegardlessOfFundingType()
@@ -78,7 +74,6 @@ namespace ProjectFirmaModels.Models
             PlanningDesignStartYear = project.PlanningDesignStartYear;
             ImplementationStartYear = project.ImplementationStartYear;
             CompletionYear = project.CompletionYear;
-            NoFundingSourceIdentifiedYet = project.NoFundingSourceIdentifiedYet;
             FundingTypeID = project.FundingTypeID;
         }
 


### PR DESCRIPTION
dropped column NoFundingSourceIdentifiedYet from Project and ProjectUpdate; migrated existing data to ProjectNoFundingSourceIdentified and ProjectNoFundingSourceIdentifiedUpdate tables; All projects save to the tables, regardless of funding type (varies by year and same each year) and tenant's budget type (annual by cost type or simple budget)