### PR TITLE
[projectfirma/#1142] Prevent user from editing after submitting

### DIFF
--- a/Source/ProjectFirma.Web/Views/Project/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Project/Detail.cshtml
@@ -90,6 +90,10 @@
     {
         <a class="btn btn-firma" href="@ViewDataTyped.ProjectWizardUrl" title="@ViewDataTyped.ProjectUpdateButtonText">@DhtmlxGridHtmlHelpers.EditIconBootstrap @ViewDataTyped.ProjectUpdateButtonText</a>
     }
+    else if (ViewDataTyped.ShowWithdrawProjectButton)
+    {
+        @ModalDialogFormHelper.ModalDialogFormLink("Withdraw this Proposal", ViewDataTyped.WithdrawUrl, "Withdraw Proposal", 500, "Withdraw", "Cancel", new List<string> { "btn btn-firma" }, null, null)
+    }
 
     @if (ViewDataTyped.ShowFactSheetButton)
     {

--- a/Source/ProjectFirma.Web/Views/Project/DetailViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/DetailViewData.cs
@@ -104,6 +104,8 @@ namespace ProjectFirma.Web.Views.Project
         public string ProjectUpdateButtonText { get; }
         public bool CanLaunchProjectOrProposalWizard { get; }
         public bool ShowFactSheetButton { get; }
+        public bool ShowWithdrawProjectButton { get; }
+        public string WithdrawUrl { get; }
         public string ProjectWizardUrl { get; }
         public string ProjectListUrl { get; }
         public string BackToProjectsText { get; }
@@ -163,6 +165,7 @@ namespace ProjectFirma.Web.Views.Project
             UserHasPerformanceMeasureActualManagePermissions = userHasPerformanceMeasureActualManagePermissions;
             UserHasProjectTimelinePermissions = userHasProjectTimelinePermissions;
             CanLaunchProjectOrProposalWizard = userHasStartUpdateWorkflowPermission;
+            WithdrawUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(c => c.Withdraw(project));
 
             var projectAlerts = new List<string>();
             var proposedProjectListUrl = SitkaRoute<ProjectController>.BuildUrlFromExpression(c => c.Proposed());
@@ -209,10 +212,23 @@ namespace ProjectFirma.Web.Views.Project
                 ProjectWizardUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.EditBasics(project.ProjectID));
                 ProjectListUrl = proposedProjectListUrl;
                 BackToProjectsText = backToAllProposalsText;
-                if (userHasProjectAdminPermissions || currentPerson.CanStewardProject(project))
+                if ((projectApprovalStatus == ProjectApprovalStatus.Draft || projectApprovalStatus == ProjectApprovalStatus.Returned) && (userHasProjectAdminPermissions || userHasStartUpdateWorkflowPermission))
                 {
                     projectAlerts.Add(
                         $"This {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} is in the Proposal stage. Any edits to this {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} must be made using the Add New {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} workflow.");
+                } 
+                else if (projectApprovalStatus == ProjectApprovalStatus.PendingApproval)
+                {
+                    if (userHasProjectAdminPermissions || currentPerson.IsPersonAProjectOwnerWhoCanStewardProjects() && currentPerson.CanStewardProject(project))
+                    {
+                        projectAlerts.Add($"This {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} has been submitted and is awaiting review.");
+                    }
+                    else if (userHasStartUpdateWorkflowPermission)
+                    {
+                        projectAlerts.Add($"This {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} has been submitted, no change can be made.");
+                        CanLaunchProjectOrProposalWizard = false;
+                        ShowWithdrawProjectButton = true;
+                    }
                 }
             }
             else if (project.IsPendingProject())
@@ -226,10 +242,24 @@ namespace ProjectFirma.Web.Views.Project
                 ProjectWizardUrl = SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.EditBasics(project.ProjectID));
                 ProjectListUrl = pendingProjectsListUrl;
                 BackToProjectsText = backToAllPendingProjectsText;
-                if (userHasProjectAdminPermissions || currentPerson.CanStewardProject(project))
+                if ((projectApprovalStatus == ProjectApprovalStatus.Draft || projectApprovalStatus == ProjectApprovalStatus.Returned) && (userHasProjectAdminPermissions || userHasStartUpdateWorkflowPermission))
                 {
                     projectAlerts.Add(
                         $"This {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} is pending. Any edits to this {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} must be made using the Add New {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} workflow.");
+                }
+                else if (projectApprovalStatus == ProjectApprovalStatus.PendingApproval)
+                {
+                    if (userHasProjectAdminPermissions || currentPerson.IsPersonAProjectOwnerWhoCanStewardProjects() && currentPerson.CanStewardProject(project))
+                    {
+                        projectAlerts.Add($"This {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} has been submitted and is awaiting review.");
+
+                    }
+                    else if (userHasStartUpdateWorkflowPermission)
+                    {
+                        projectAlerts.Add($"This {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} is pending, no change can be made.");
+                        CanLaunchProjectOrProposalWizard = false;
+                        ShowWithdrawProjectButton = true;
+                    }
                 }
             }
             else

--- a/Source/ProjectFirma.Web/Views/Project/PendingGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/PendingGridSpec.cs
@@ -36,7 +36,12 @@ namespace ProjectFirma.Web.Views.Project
         {
             // todo: fulfill "Include standard project grid with columns for “Stage” and “Approval Status”
             Add(string.Empty, x => DhtmlxGridHtmlHelpers.MakeDeleteIconAndLinkBootstrap(x.GetDeleteProposalUrl(), new ProjectDeleteProposalFeature().HasPermission(currentFirmaSession, x).HasPermission, true), 30, DhtmlxGridColumnFilterType.None);
-            Add(string.Empty, x => DhtmlxGridHtmlHelpers.MakeEditIconAsHyperlinkBootstrap(x.GetProjectCreateUrl(), new ProjectCreateFeature().HasPermission(currentFirmaSession, x).HasPermission), 30, DhtmlxGridColumnFilterType.None);
+            Add(string.Empty,
+                x => DhtmlxGridHtmlHelpers.MakeEditIconAsHyperlinkBootstrap(x.GetProjectCreateUrl(),
+                    new ProjectCreateFeature().HasPermission(currentFirmaSession, x).HasPermission &&
+                    !(x.ProjectApprovalStatus == ProjectApprovalStatus.PendingApproval &&
+                      currentFirmaSession.Role == ProjectFirmaModels.Models.Role.Normal)), 30,
+                DhtmlxGridColumnFilterType.None);
             Add(FieldDefinitionEnum.ProjectName.ToType().ToGridHeaderString(), x => UrlTemplate.MakeHrefString(x.GetDetailUrl(), x.ProjectName), 300, DhtmlxGridColumnFilterType.Html);
             Add("Submittal Status", a => a.ProjectApprovalStatus.ProjectApprovalStatusDisplayName, 110, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(FieldDefinitionEnum.ProjectStage.ToType().ToGridHeaderString(), x => x.ProjectStage.ProjectStageDisplayName, 90, DhtmlxGridColumnFilterType.SelectFilterStrict);

--- a/Source/ProjectFirma.Web/Views/Project/ProposalsGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ProposalsGridSpec.cs
@@ -40,7 +40,12 @@ namespace ProjectFirma.Web.Views.Project
                 return DhtmlxGridHtmlHelpers.MakeDeleteIconAndLinkBootstrap(x.GetDeleteProposalUrl(),
                         userHasDeletePermission, true);
             }, 30, DhtmlxGridColumnFilterType.None);
-            Add(string.Empty, x => DhtmlxGridHtmlHelpers.MakeEditIconAsHyperlinkBootstrap(x.GetProjectCreateUrl(), new ProjectCreateFeature().HasPermission(firmaSession, x).HasPermission), 30, DhtmlxGridColumnFilterType.None);
+            Add(string.Empty,
+                x => DhtmlxGridHtmlHelpers.MakeEditIconAsHyperlinkBootstrap(x.GetProjectCreateUrl(),
+                    new ProjectCreateFeature().HasPermission(firmaSession, x).HasPermission &&
+                    !(x.ProjectApprovalStatus == ProjectApprovalStatus.PendingApproval &&
+                      firmaSession.Role == ProjectFirmaModels.Models.Role.Normal)), 30,
+                DhtmlxGridColumnFilterType.None);
             Add(FieldDefinitionEnum.ProjectName.ToType().ToGridHeaderString(), x => UrlTemplate.MakeHrefString(x.GetDetailUrl(), x.ProjectName), 300, DhtmlxGridColumnFilterType.Html);
             Add("Submittal Status", a => a.ProjectApprovalStatus.ProjectApprovalStatusDisplayName, 110, DhtmlxGridColumnFilterType.SelectFilterStrict);
             if (MultiTenantHelpers.HasCanStewardProjectsOrganizationRelationship())


### PR DESCRIPTION
Prevent normal user from editing after submitting proposal or pending project.

Give the normal users access to a "withdraw this proposal" option from the detail page if they previously had access to the create project workflow for that proposal/project.