### PR TITLE
[projectfirma/#1250] Better syncing of Organization info with Keystone

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/OrganizationController.cs
+++ b/Source/ProjectFirma.Web/Controllers/OrganizationController.cs
@@ -155,8 +155,20 @@ namespace ProjectFirma.Web.Controllers
                 x => x.GetFullNameFirstLastAndOrg());
             var isSitkaAdmin = new SitkaAdminFeature().HasPermissionByFirmaSession(CurrentFirmaSession);
             var userHasAdminPermissions = new FirmaAdminFeature().HasPermissionByFirmaSession(CurrentFirmaSession);
-            var viewData = new EditViewData(organizationTypesAsSelectListItems, people, isInKeystone, SitkaRoute<HelpController>.BuildUrlFromExpression(x => x.RequestOrganizationNameChange()), isSitkaAdmin, userHasAdminPermissions);
+            var viewData = new EditViewData(organizationTypesAsSelectListItems, people, isInKeystone, SitkaRoute<HelpController>.BuildUrlFromExpression(x => x.RequestOrganizationNameChange()), isSitkaAdmin, userHasAdminPermissions, viewModel.OrganizationGuid);
             return RazorPartialView<Edit, EditViewData, EditViewModel>(viewData, viewModel);
+        }
+
+        [HttpGet]
+        [OrganizationManageFeature]
+        public JsonResult SyncWithKeystone(string organizationGuidAsString)
+        {
+            var keystoneClient = new KeystoneDataClient();
+            var organizationGuid = Guid.Parse(organizationGuidAsString);
+            var keystoneOrganization = keystoneClient.GetOrganization(organizationGuid);
+            // create an OrganizationSimple with fields to be synced from Keystone set (ShortName and URL)
+            var result = new OrganizationSimple(default(int), keystoneOrganization.OrganizationGuid, keystoneOrganization.FullName, keystoneOrganization.ShortName, default(int), null, true, keystoneOrganization.URL, null, string.Empty);
+            return Json(result, JsonRequestBehavior.AllowGet);
         }
 
         [HttpGet]

--- a/Source/ProjectFirma.Web/Views/FieldDefinition/EditViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/FieldDefinition/EditViewModel.cs
@@ -23,10 +23,12 @@ using System.ComponentModel.DataAnnotations;
 using System.Web;
 using ProjectFirmaModels.Models;
 using LtInfo.Common.Models;
+using System.Collections.Generic;
+using LtInfo.Common;
 
 namespace ProjectFirma.Web.Views.FieldDefinition
 {
-    public class EditViewModel : FormViewModel
+    public class EditViewModel : FormViewModel, IValidatableObject
     {
         [DisplayName("Custom Definition")]
         public HtmlString FieldDefinitionDataValue { get; set; }
@@ -60,6 +62,16 @@ namespace ProjectFirma.Web.Views.FieldDefinition
             {
                 fieldDefinitionDefault.DefaultDefinitionHtmlString = FieldDefinitionDefault;
             }
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            var validationResults = new List<ValidationResult>();
+            if (FieldDefinitionDefault == null)
+            {
+                validationResults.Add(new SitkaValidationResult<EditViewModel, HtmlString>("Default Definition is required.", x => x.FieldDefinitionDefault));
+            }
+            return validationResults;
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Organization/Edit.cshtml
+++ b/Source/ProjectFirma.Web/Views/Organization/Edit.cshtml
@@ -18,6 +18,7 @@ GNU Affero General Public License <http://www.gnu.org/licenses/> for more detail
 Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*@
+@using LtInfo.Common
 @using LtInfo.Common.HtmlHelperExtensions
 @using LtInfo.Common.ModalDialog
 @using LtInfo.Common.Mvc
@@ -29,7 +30,7 @@ Source code is available upon request via <support@sitkatech.com>.
 {
     if (ViewDataTyped.IsInKeystone)
     {
-        <p class="systemText">Because this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel() has user accounts associated with it, its Name, Short Name, and Home Page information come from Keystone. To change this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()'s Name, please @ModalDialogFormHelper.ModalDialogFormLink("submit a support request", ViewDataTyped.RequestOrganizationChangeUrl, "Request Support", 800, "Submit Request", "Cancel", new List<string>(), null, null). While you may update this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()'s Short Name and Home Page here, try syncing from Keystone first.</p>
+        <p id="keystoneParagraph" class="systemText">Because this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel() has user accounts associated with it, its Name, Short Name, and Home Page information come from Keystone. To change this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()'s Name, please @ModalDialogFormHelper.ModalDialogFormLink("submit a support request", ViewDataTyped.RequestOrganizationChangeUrl, "Request Support", 800, "Submit Request", "Cancel", new List<string>(), null, null). While you may update this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()'s Short Name and Home Page here, try syncing from Keystone first.</p>
     }
     <div class="form-horizontal">
         <div class="form-group">
@@ -71,11 +72,11 @@ Source code is available upon request via <support@sitkatech.com>.
         {
             <div class="form-group">
                 <div class="col-sm-3 control-label">
-                    @Html.LabelWithSugarFor(m => m.SyncWithKeystone)
                 </div>
                 <div class="col-sm-9">
-                    @Html.CheckBoxFor(m => m.SyncWithKeystone)
-                    @Html.ValidationMessageFor(m => m.SyncWithKeystone)
+                    <button class="btn btn-firma" type="button" onclick="syncWithKeystone()" title="Sync Short Name and Home Page values with the values stored in Keystone for this Organization.">
+                        Sync with Keystone
+                    </button>
                 </div>
             </div>
         }
@@ -141,23 +142,35 @@ Source code is available upon request via <support@sitkatech.com>.
 
 
 <script type="text/javascript">
+
+    function syncWithKeystone() {
+        var organizationGuid = "@Html.Raw(ViewDataTyped.OrganizationGuid.ToString())";
+        var urlTemplate = new Sitka.UrlTemplate(@Html.Raw(ViewDataTyped.SyncWithKeystoneUrl.ToJS()));
+        var newUrl = urlTemplate.ParameterReplace(organizationGuid);
+
+        var successHandler = function(result) {
+            var shortNameInput = jQuery("#@Html.IdFor(x => x.OrganizationShortName)");
+            var urlInput = jQuery("#@Html.IdFor(x => x.OrganizationUrl)");
+            shortNameInput.val(result.OrganizationShortName);
+            urlInput.val(result.URL);
+
+            jQuery("#keystoneParagraph").prepend("<div class=\"alert alert-info\" role=\"alert\">" +
+                "<button type=\"button\" class=\"close\" data-dismiss=\"alert\" aria-label=\"Close\">&times;</button>" +
+                "Sync with Keystone successfully replaced the Short Name and Home Page in this editor. You must save changes to update this Organization.</div>");
+        };
+
+        var errorHandler = function(error) {
+            jQuery("#keystoneParagraph").prepend("<div class=\"alert alert-danger\" role=\"alert\">" +
+                "<button type=\"button\" class=\"close\" data-dismiss=\"alert\" aria-label=\"Close\">&times;</button>" +
+                "Cannot sync with Keystone. Organization not found in Keystone or unable to connect to Keystone.</div>");
+        };
+
+        SitkaAjax.get(newUrl, successHandler, errorHandler);
+    }
+
     jQuery(document).ready(function ()
     {
         HookupCheckIfFormIsDirty(undefined, ".submitProject");
-
-        jQuery("#@Html.IdFor(x => x.SyncWithKeystone)").on('change', function () {
-            var isChecked = jQuery(this).is(':checked');
-            var shortNameInput = jQuery("#@Html.IdFor(x => x.OrganizationShortName)");
-            var urlInput = jQuery("#@Html.IdFor(x => x.OrganizationUrl)");
-            shortNameInput.prop("disabled", isChecked);
-            urlInput.prop("disabled", isChecked);
-            if (isChecked) {
-                shortNameInput.prop("title", "Synced with Keystone on Save is selected. Cannot edit.");
-                urlInput.prop("title", "Synced with Keystone on Save is selected. Cannot edit");
-            } else {
-                shortNameInput.prop("title", "");
-                urlInput.prop("title", "");
-            }
-        });
     });
+
 </script>

--- a/Source/ProjectFirma.Web/Views/Organization/EditViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/EditViewData.cs
@@ -18,8 +18,13 @@ GNU Affero General Public License <http://www.gnu.org/licenses/> for more detail
 Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*/
+
+using System;
 using System.Collections.Generic;
 using System.Web.Mvc;
+using LtInfo.Common;
+using ProjectFirma.Web.Common;
+using ProjectFirma.Web.Controllers;
 
 namespace ProjectFirma.Web.Views.Organization
 {
@@ -31,8 +36,10 @@ namespace ProjectFirma.Web.Views.Organization
         public readonly string RequestOrganizationChangeUrl;
         public readonly bool IsSitkaAdmin;
         public readonly bool UserHasAdminPermissions;
+        public readonly Guid? OrganizationGuid;
+        public readonly string SyncWithKeystoneUrl;
 
-        public EditViewData(IEnumerable<SelectListItem> organizationTypes, IEnumerable<SelectListItem> people, bool isInKeystone, string requestOrganizationChangeUrl, bool isSitkaAdmin, bool userHasAdminPermissions)
+        public EditViewData(IEnumerable<SelectListItem> organizationTypes, IEnumerable<SelectListItem> people, bool isInKeystone, string requestOrganizationChangeUrl, bool isSitkaAdmin, bool userHasAdminPermissions, Guid? organizationGuid)
         {
             OrganizationTypes = organizationTypes;
             People = people;
@@ -40,6 +47,8 @@ namespace ProjectFirma.Web.Views.Organization
             RequestOrganizationChangeUrl = requestOrganizationChangeUrl;
             IsSitkaAdmin = isSitkaAdmin;
             UserHasAdminPermissions = userHasAdminPermissions;
+            OrganizationGuid = organizationGuid;
+            SyncWithKeystoneUrl = SitkaRoute<OrganizationController>.BuildUrlFromExpression(x => x.SyncWithKeystone(UrlTemplate.Parameter1String));
         }
     }
 }


### PR DESCRIPTION
revisiting and reworking: 
removed the Sync with Keystone On Save checkbox, and added a button that gets the short name and URL from keystone and replaces the values in the editor. User must save the editor to save the changes to the PF Database; 

Also pork: prevent crashes on the sitka admin field definition editor by making the Default Definition required