### PR TITLE
[projectfirma/#2131] Bugs with proposal and pending project workflows

### DIFF
--- a/Source/ProjectFirma.Web/Views/Shared/ProjectContact/EditContacts.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectContact/EditContacts.cshtml
@@ -65,7 +65,7 @@
     <div id="EditContactsAngularApp" ng-controller="ProjectContactController">
         <div class="row">
             <div class="col-md-12">
-                <p>Select the Contacts that are associated with your @(FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()). Some association types have a single contact (e.g. @(FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabel())); these are marked with a required symbol (<sup>@Html.Raw(BootstrapHtmlHelpers.RequiredIcon)</sup>). Other relationship types can apply to any number of contacts and are not required.</p>
+                <p>Select the Contacts that are associated with your @(FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()).</p>
             </div>
         </div>
         <hr />

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectOrganization/EditOrganizations.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectOrganization/EditOrganizations.cshtml
@@ -67,7 +67,7 @@ Source code is available upon request via <support@sitkatech.com>.
 <div id="EditOrganizationsAngularApp" ng-controller="ProjectOrganizationController">
     <div class="row">
         <div class="col-md-12">
-            <p>Select the @FieldDefinitionEnum.OrganizationPrimaryContact.ToType().GetFieldDefinitionLabel() and @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabelPluralized() that are associated with your @(FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()). Some association types have a single organization; these are marked with a required symbol (<sup>@Html.Raw(BootstrapHtmlHelpers.RequiredIcon)</sup>). Other assocation types apply to any number of organizations and are not required.</p>
+            <p>Select the @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabelPluralized() that are associated with your @(FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()). Some association types have a single organization; these are marked with a required symbol (<sup>@Html.Raw(BootstrapHtmlHelpers.RequiredIcon)</sup>). Other assocation types apply to any number of organizations and are not required.</p>
             <p class="systemText">@FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel() Funders are not set in this editor. Funders are automatically identified by the @FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized() in the @FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel() Budget and Reported Expenditures.</p>
         </div>
     </div>
@@ -99,20 +99,6 @@ Source code is available upon request via <support@sitkatech.com>.
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <p class="help-block alert alert-info">
-                    <span ng-show="AngularViewData.PrimaryContactRelationshipTypeSimple != null">The default @FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabel() is the person set as the @FieldDefinitionEnum.OrganizationPrimaryContact.ToType().GetFieldDefinitionLabel() for the <span ng-bind="AngularViewData.PrimaryContactRelationshipTypeSimple.OrganizationRelationshipTypeName"></span>, if there is one. </span>
-                    <span>Currently, this means <span style="font-weight: bold" ng-bind="primaryContactOrganizationPersonDisplayName(AngularViewData.PrimaryContactRelationshipTypeSimple)"></span> will be the @(FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabel()).</span>
-                    <span>@Html.Raw(ViewDataTyped.RequestSupportLink) to ask an administrator to set a @(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().GetFieldDefinitionLabel()) for <span ng-bind="AngularViewData.PrimaryContactRelationshipTypeSimple.OrganizationRelationshipTypeName"></span>.</span>
-                    <span ng-show="AngularViewData.PrimaryContactRelationshipTypeSimple != null && primaryContactOrganizationHasNoPrimaryContact(AngularViewData.PrimaryContactRelationshipTypeSimple)">
-                        Consider setting a @FieldDefinitionEnum.OrganizationPrimaryContact.ToType().GetFieldDefinitionLabel() for <a href="{{primaryContactOrganization(AngularViewData.PrimaryContactRelationshipTypeSimple).DetailUrl}}" alt="{{primaryContactOrganization(AngularViewData.PrimaryContactRelationshipTypeSimple).OrganizationName}}" ng-bind="primaryContactOrganization(AngularViewData.PrimaryContactRelationshipTypeSimple).OrganizationName"></a>.
-                    </span>
-                    <br />
-                    You may change the @FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabel() in the Contacts section of the Project Workflow.
-                </p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
When saving the basics section of the project create workflow for the first time, save the lead implementor and primary contact that is currently defaulted on the Organization section of Contacts section, respectively. Previous, the defaults were selected, but not saved, so the Organization and Contacts pages appeared complete when they were not. Also cleaned up the instructions text and removed the growl message about the primary contact from the Organziation page