### PR TITLE
[projectfirma/#1076] rework: make Pages selectpicker always a 'dropup'

### DIFF
--- a/Source/ProjectFirma.Web/Views/DocumentLibrary/Edit.cshtml
+++ b/Source/ProjectFirma.Web/Views/DocumentLibrary/Edit.cshtml
@@ -93,7 +93,7 @@
             <div class="col-md-3 control-label">@Html.LabelWithSugarFor(m => m.CustomPageIDs)</div>
             <div class="col-md-9">
                 <div class="input-group" style="width: 100%;">
-                    <select class="selectpicker" ng-model="CustomPageIDToAdd" data-live-search="true"  data-size="6" title="Select one">
+                    <select class="selectpicker dropup" ng-model="CustomPageIDToAdd" data-live-search="true"  data-size="6" title="Select one" data-dropup-auto="false">
                         <option ng-repeat="customPage in getAvailableCustomPages()"
                                 ng-selected="CustomPageIDToAdd == customPage.CustomPageID"
                                 ng-bind="customPage.CustomPageDisplayName"


### PR DESCRIPTION
make the Pages selectpicker always a 'dropup' so users don't have to scroll in the modal to see the options