### PR TITLE
[projectfirma/#2131] Rework

### DIFF
--- a/Source/ProjectFirma.Web/Models/FieldDefinitionModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/FieldDefinitionModelExtensions.cs
@@ -62,7 +62,7 @@ namespace ProjectFirma.Web.Models
 
         public static IFieldDefinitionData GetFieldDefinitionData(this FieldDefinition fieldDefinition)
         {
-            return fieldDefinition.FieldDefinitionDatas.SingleOrDefault(x => x.TenantID == HttpRequestStorage.Tenant.TenantID);
+            return fieldDefinition.FieldDefinitionDatas.SingleOrDefault(x => x.TenantID == HttpRequestStorage.DatabaseEntities.TenantID);
         }
 
         public static string GetContentUrl(this FieldDefinition fieldDefinition)

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectOrganization/EditOrganizations.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectOrganization/EditOrganizations.cshtml
@@ -67,7 +67,7 @@ Source code is available upon request via <support@sitkatech.com>.
 <div id="EditOrganizationsAngularApp" ng-controller="ProjectOrganizationController">
     <div class="row">
         <div class="col-md-12">
-            <p>Select the @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabelPluralized() that are associated with your @(FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()). Some association types have a single organization; these are marked with a required symbol (<sup>@Html.Raw(BootstrapHtmlHelpers.RequiredIcon)</sup>). Other assocation types apply to any number of organizations and are not required.</p>
+            <p>Select the @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabelPluralized() that are associated with your @(FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()). Some association types have a single organization; these are marked with a required symbol (<sup>@Html.Raw(BootstrapHtmlHelpers.RequiredIcon)</sup>). Other association types apply to any number of organizations and are not required.</p>
             <p class="systemText">@FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel() Funders are not set in this editor. Funders are automatically identified by the @FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized() in the @FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel() Budget and Reported Expenditures.</p>
         </div>
     </div>


### PR DESCRIPTION
Fixed typo in Edit Organizations instructions. 
Attempting to fix issue where we display the wrong field definition label for some tenants (e.g.: project update shows Near Term Action Custom Attributes for John Day)