### PR TITLE
[projectfirma/#2136] Bug fix: LabelFor() and FieldDefinitionDisplay 

### DIFF
--- a/Source/ProjectFirma.Web/Common/LabelForExtensions.cs
+++ b/Source/ProjectFirma.Web/Common/LabelForExtensions.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Web;
 using System.Web.Mvc;
+using System.Web.Mvc.Html;
 using LtInfo.Common;
 using LtInfo.Common.BootstrapWrappers;
 using LtInfo.Common.HtmlHelperExtensions;
@@ -78,6 +79,7 @@ namespace ProjectFirma.Web.Common
         {
             return LabelWithSugarFor(fieldDefinition, displayStyle, fieldDefinition.GetFieldDefinitionLabel());
         }
+
 
         /// <summary>
         /// Does what LabelWithHelpFor does and adds a help icon
@@ -254,4 +256,146 @@ namespace ProjectFirma.Web.Common
             return new MvcHtmlString(fieldDefinitionLinkTag.ToString(TagRenderMode.Normal));
         }
     }
+
+    public static class LabelForExtensions
+    {
+        /// <summary>
+        /// ProjectFirma LabelFor that respects Tenant's Field Definition. Returns an HTML label element and the property name of the property that is represented by the specified expression.
+        /// </summary>
+        /// <returns>An HTML label element and the property name of the property that is represented by the expression.</returns>
+        /// <param name="html">The HTML helper instance that this method extends.</param>
+        /// <param name="expression">An expression that identifies the property to display.</param>
+        /// <param name="getTenantFieldDefinition">A dummy param to differentiate the method signature from LabelExtension.LabelFor</param>
+        /// <typeparam name="TViewModel">The type of the model.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        public static MvcHtmlString LabelFor<TViewModel, TValue>(this HtmlHelper<TViewModel> html, Expression<Func<TViewModel, TValue>> expression, bool getTenantFieldDefinition)
+        {
+            return LabelWithoutSugarFor(html, expression, null, null);
+        }
+
+        /// <summary>
+        /// ProjectFirma LabelFor that respects Tenant's Field Definition. Returns an HTML label element and the property name of the property that is represented by the specified expression using the label text.
+        /// </summary>
+        /// <returns>An HTML label element and the property name of the property that is represented by the expression.</returns>
+        /// <param name="html">The HTML helper instance that this method extends.</param>
+        /// <param name="expression">An expression that identifies the property to display.</param>
+        /// <param name="labelText">The label text to display.</param>
+        /// <param name="getTenantFieldDefinition">A dummy param to differentiate the method signature from LabelExtension.LabelFor</param>
+        /// <typeparam name="TViewModel">The type of the model.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        public static MvcHtmlString LabelFor<TViewModel, TValue>(this HtmlHelper<TViewModel> html, Expression<Func<TViewModel, TValue>> expression, string labelText, bool getTenantFieldDefinition)
+        {
+            return LabelWithoutSugarFor(html, expression, labelText, null);
+        }
+
+        /// <summary>
+        /// ProjectFirma LabelFor that respects Tenant's Field Definition. Returns an HTML label element and the property name of the property that is represented by the specified expression.
+        /// </summary>
+        /// <returns>An HTML label element and the property name of the property that is represented by the expression.</returns>
+        /// <param name="html">The HTML helper instance that this method extends.</param>
+        /// <param name="expression">An expression that identifies the property to display.</param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.</param>
+        /// <param name="getTenantFieldDefinition">A dummy param to differentiate the method signature from LabelExtension.LabelFor </param>
+        /// <typeparam name="TViewModel">The type of the model.</typeparam>
+        /// <typeparam name="TValue">The value.</typeparam>
+        public static MvcHtmlString LabelFor<TViewModel, TValue>(this HtmlHelper<TViewModel> html, Expression<Func<TViewModel, TValue>> expression, object htmlAttributes, bool getTenantFieldDefinition)
+        {
+            return LabelWithoutSugarFor(html, expression, null, htmlAttributes);
+        }
+
+        /// <summary>
+        /// ProjectFirma LabelFor that respects Tenant's Field Definition. Returns an HTML label element and the property name of the property that is represented by the specified expression.
+        /// </summary>
+        /// <returns>An HTML label element and the property name of the property that is represented by the expression.</returns>
+        /// <param name="html">The HTML helper instance that this method extends.</param>
+        /// <param name="expression">An expression that identifies the property to display.</param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.</param>
+        /// <param name="getTenantFieldDefinition">A dummy param to differentiate the method signature from LabelExtension.LabelFor </param>
+        /// <typeparam name="TViewModel">The type of the model.</typeparam>
+        /// <typeparam name="TValue">The value.</typeparam>
+        public static MvcHtmlString LabelFor<TViewModel, TValue>(this HtmlHelper<TViewModel> html, Expression<Func<TViewModel, TValue>> expression, IDictionary<string, object> htmlAttributes, bool getTenantFieldDefinition)
+        {
+            return LabelWithoutSugarFor(html, expression, null, htmlAttributes);
+        }
+
+        /// <summary>
+        /// ProjectFirma LabelFor that respects Tenant's Field Definition. Returns an HTML label element and the property name of the property that is represented by the specified expression using the label text.
+        /// </summary>
+        /// <returns>An HTML label element and the property name of the property that is represented by the expression.</returns>
+        /// <param name="html">The HTML helper instance that this method extends.</param>
+        /// <param name="expression">An expression that identifies the property to display.</param>
+        /// <param name="labelText">The label text to display.</param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.</param>
+        /// <param name="getTenantFieldDefinition">A dummy param to differentiate the method signature from LabelExtension.LabelFor</param>
+        /// <typeparam name="TViewModel">The type of the model.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        public static MvcHtmlString LabelFor<TViewModel, TValue>(this HtmlHelper<TViewModel> html, Expression<Func<TViewModel, TValue>> expression, string labelText, object htmlAttributes, bool getTenantFieldDefinition)
+        {
+            return LabelWithoutSugarFor(html, expression, labelText, htmlAttributes);
+        }
+
+
+        /// <summary>
+        /// ProjectFirma LabelFor that respects Tenant's Field Definition. Returns an HTML label element and the property name of the property that is represented by the specified expression using the label text.
+        /// </summary>
+        /// <returns>An HTML label element and the property name of the property that is represented by the expression.</returns>
+        /// <param name="html">The HTML helper instance that this method extends.</param>
+        /// <param name="expression">An expression that identifies the property to display.</param>
+        /// <param name="labelText">The label text to display.</param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.</param>
+        /// <param name="getTenantFieldDefinition">A dummy param to differentiate the method signature from LabelExtension.LabelFor</param>
+        /// <typeparam name="TViewModel">The type of the model.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        public static MvcHtmlString LabelFor<TViewModel, TValue>(this HtmlHelper<TViewModel> html, Expression<Func<TViewModel, TValue>> expression, string labelText, IDictionary<string, object> htmlAttributes, bool getTenantFieldDefinition)
+        {
+            return LabelWithoutSugarFor(html, expression, labelText, htmlAttributes);
+        }
+
+        private static MvcHtmlString LabelWithoutSugarFor<TViewModel, TValue>(this HtmlHelper<TViewModel> html,
+            Expression<Func<TViewModel, TValue>> expression, string labelText, object htmlAttributes)
+        {
+            var memberExpression = (expression.Body as MemberExpression);
+            if (memberExpression == null)
+            {
+                return new MvcHtmlString(string.Empty);
+            }
+            var fieldDefinitionDisplayAttributeType = typeof(IFieldDefinitionDisplayAttribute);
+            var fieldDefinitionDisplayAttribute = memberExpression.Member.GetCustomAttributes(fieldDefinitionDisplayAttributeType, true).Cast<IFieldDefinitionDisplayAttribute>().SingleOrDefault();
+
+            if (fieldDefinitionDisplayAttribute == null)
+            {
+                return html.LabelFor(expression, labelText, htmlAttributes);
+            }
+            else
+            {
+                var fieldDefinition = fieldDefinitionDisplayAttribute.FieldDefinition;
+                var fieldDefinitionDisplayName = string.IsNullOrWhiteSpace(labelText) ? fieldDefinition.GetFieldDefinitionLabel() : labelText;
+                return html.LabelFor(expression, fieldDefinitionDisplayName, htmlAttributes);
+            }
+        }
+
+        private static MvcHtmlString LabelWithoutSugarFor<TViewModel, TValue>(this HtmlHelper<TViewModel> html,
+            Expression<Func<TViewModel, TValue>> expression, string labelText, IDictionary<string, object> htmlAttributes)
+        {
+            var memberExpression = (expression.Body as MemberExpression);
+            if (memberExpression == null)
+            {
+                return new MvcHtmlString(string.Empty);
+            }
+            var fieldDefinitionDisplayAttributeType = typeof(IFieldDefinitionDisplayAttribute);
+            var fieldDefinitionDisplayAttribute = memberExpression.Member.GetCustomAttributes(fieldDefinitionDisplayAttributeType, true).Cast<IFieldDefinitionDisplayAttribute>().SingleOrDefault();
+
+            if (fieldDefinitionDisplayAttribute == null)
+            {
+                return html.LabelFor(expression, labelText, htmlAttributes);
+            }
+            else
+            {
+                var fieldDefinition = fieldDefinitionDisplayAttribute.FieldDefinition;
+                var fieldDefinitionDisplayName = string.IsNullOrWhiteSpace(labelText) ? fieldDefinition.GetFieldDefinitionLabel() : labelText;
+                return html.LabelFor(expression, fieldDefinitionDisplayName, htmlAttributes);
+            }
+        }
+    }
+
 }

--- a/Source/ProjectFirma.Web/Views/DocumentLibrary/EditDocument.cshtml
+++ b/Source/ProjectFirma.Web/Views/DocumentLibrary/EditDocument.cshtml
@@ -58,11 +58,11 @@
                 @Html.LabelWithSugarFor(FieldDefinitionEnum.DocumentLibraryDocumentViewableBy.ToType(), "Viewable By") <sup>@Html.Raw(BootstrapHtmlHelpers.RequiredIcon)</sup>
             </div>
             <div class="col-md-9">
-                @Html.CheckBoxFor(x => x.ViewableByAnonymous) @Html.LabelFor(x => x.ViewableByAnonymous, new { style = "font-weight : normal; padding-right : 10px;" })
-                @Html.CheckBoxFor(x => x.ViewableByUnassigned) @Html.LabelFor(x => x.ViewableByUnassigned, new { style = "font-weight : normal; padding-right : 10px;" })
-                @Html.CheckBoxFor(x => x.ViewableByNormal) @Html.LabelFor(x => x.ViewableByNormal, new { style = "font-weight : normal; padding-right : 10px;" })
-                @Html.CheckBoxFor(x => x.ViewableByProjectSteward) @Html.LabelFor(x => x.ViewableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" })
-                @Html.CheckBoxFor(x => x.ViewableByAdmin) @Html.LabelFor(x => x.ViewableByAdmin, new { style = "font-weight : normal; padding-right : 10px;" })
+                @Html.CheckBoxFor(x => x.ViewableByAnonymous) @Html.LabelFor(x => x.ViewableByAnonymous, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                @Html.CheckBoxFor(x => x.ViewableByUnassigned) @Html.LabelFor(x => x.ViewableByUnassigned, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                @Html.CheckBoxFor(x => x.ViewableByNormal) @Html.LabelFor(x => x.ViewableByNormal, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                @Html.CheckBoxFor(x => x.ViewableByProjectSteward) @Html.LabelFor(x => x.ViewableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                @Html.CheckBoxFor(x => x.ViewableByAdmin) @Html.LabelFor(x => x.ViewableByAdmin, new { style = "font-weight : normal; padding-right : 10px;" }, true)
             </div>
         </div>
     </div>

--- a/Source/ProjectFirma.Web/Views/DocumentLibrary/NewDocument.cshtml
+++ b/Source/ProjectFirma.Web/Views/DocumentLibrary/NewDocument.cshtml
@@ -69,11 +69,11 @@
                 @Html.LabelWithSugarFor(FieldDefinitionEnum.DocumentLibraryDocumentViewableBy.ToType(), "Viewable By") <sup>@Html.Raw(BootstrapHtmlHelpers.RequiredIcon)</sup>
             </div>
             <div class="col-md-9">
-                @Html.CheckBoxFor(x => x.ViewableByAnonymous) @Html.LabelFor(x => x.ViewableByAnonymous, new { style = "font-weight : normal; padding-right : 10px;" })
-                @Html.CheckBoxFor(x => x.ViewableByUnassigned) @Html.LabelFor(x => x.ViewableByUnassigned, new { style = "font-weight : normal; padding-right : 10px;" })
-                @Html.CheckBoxFor(x => x.ViewableByNormal) @Html.LabelFor(x => x.ViewableByNormal, new { style = "font-weight : normal; padding-right : 10px;" })
-                @Html.CheckBoxFor(x => x.ViewableByProjectSteward) @Html.LabelFor(x => x.ViewableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" })
-                @Html.CheckBoxFor(x => x.ViewableByAdmin) @Html.LabelFor(x => x.ViewableByAdmin, new { style = "font-weight : normal; padding-right : 10px;" })
+                @Html.CheckBoxFor(x => x.ViewableByAnonymous) @Html.LabelFor(x => x.ViewableByAnonymous, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                @Html.CheckBoxFor(x => x.ViewableByUnassigned) @Html.LabelFor(x => x.ViewableByUnassigned, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                @Html.CheckBoxFor(x => x.ViewableByNormal) @Html.LabelFor(x => x.ViewableByNormal, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                @Html.CheckBoxFor(x => x.ViewableByProjectSteward) @Html.LabelFor(x => x.ViewableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                @Html.CheckBoxFor(x => x.ViewableByAdmin) @Html.LabelFor(x => x.ViewableByAdmin, new { style = "font-weight : normal; padding-right : 10px;" }, true)
             </div>
         </div>
     </div>

--- a/Source/ProjectFirma.Web/Views/FundingSourceCustomAttributeType/Edit.cshtml
+++ b/Source/ProjectFirma.Web/Views/FundingSourceCustomAttributeType/Edit.cshtml
@@ -144,9 +144,9 @@
                         @Html.LabelWithSugarFor(@FieldDefinitionEnum.FundingSourceCustomAttributeTypeViewableBy.ToType())
                     </div>
                     <div class="col-sm-9">
-                        @Html.CheckBoxFor(x => x.ViewableByUnassigned) @Html.LabelFor(x => x.ViewableByUnassigned, new { style = "font-weight : normal; padding-right : 10px;" })
-                        @Html.CheckBoxFor(x => x.ViewableByNormal) @Html.LabelFor(x => x.ViewableByNormal, new { style = "font-weight : normal; padding-right : 10px;" })
-                        @Html.CheckBoxFor(x => x.ViewableByProjectSteward) @Html.LabelFor(x => x.ViewableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" })
+                        @Html.CheckBoxFor(x => x.ViewableByUnassigned) @Html.LabelFor(x => x.ViewableByUnassigned, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                        @Html.CheckBoxFor(x => x.ViewableByNormal) @Html.LabelFor(x => x.ViewableByNormal, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                        @Html.CheckBoxFor(x => x.ViewableByProjectSteward) @Html.LabelFor(x => x.ViewableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" }, true)
                     </div>
                 </div>
                 <div class="form-group">

--- a/Source/ProjectFirma.Web/Views/ProjectCustomAttributeType/Edit.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCustomAttributeType/Edit.cshtml
@@ -153,8 +153,8 @@
                         @Html.LabelWithSugarFor(@FieldDefinitionEnum.ProjectCustomAttributeTypeEditableBy.ToType())
                     </div>
                     <div class="col-sm-9">
-                        @Html.CheckBoxFor(x => x.EditableByNormal) @Html.LabelFor(x => x.EditableByNormal, new { style = "font-weight : normal; padding-right : 10px;" })
-                        @Html.CheckBoxFor(x => x.EditableByProjectSteward) @Html.LabelFor(x => x.EditableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" })
+                        @Html.CheckBoxFor(x => x.EditableByNormal) @Html.LabelFor(x => x.EditableByNormal, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                        @Html.CheckBoxFor(x => x.EditableByProjectSteward) @Html.LabelFor(x => x.EditableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" }, true)
                     </div>
                 </div>
                 <div class="form-group">
@@ -162,10 +162,10 @@
                         @Html.LabelWithSugarFor(@FieldDefinitionEnum.ProjectCustomAttributeTypeViewableBy.ToType())
                     </div>
                     <div class="col-sm-9">
-                        @Html.CheckBoxFor(x => x.ViewableByAnonymous) @Html.LabelFor(x => x.ViewableByAnonymous, new { style = "font-weight : normal; padding-right : 10px;" })
-                        @Html.CheckBoxFor(x => x.ViewableByUnassigned) @Html.LabelFor(x => x.ViewableByUnassigned, new { style = "font-weight : normal; padding-right : 10px;" })
-                        @Html.CheckBoxFor(x => x.ViewableByNormal) @Html.LabelFor(x => x.ViewableByNormal, new { style = "font-weight : normal; padding-right : 10px;" })
-                        @Html.CheckBoxFor(x => x.ViewableByProjectSteward) @Html.LabelFor(x => x.ViewableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" })
+                        @Html.CheckBoxFor(x => x.ViewableByAnonymous) @Html.LabelFor(x => x.ViewableByAnonymous, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                        @Html.CheckBoxFor(x => x.ViewableByUnassigned) @Html.LabelFor(x => x.ViewableByUnassigned, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                        @Html.CheckBoxFor(x => x.ViewableByNormal) @Html.LabelFor(x => x.ViewableByNormal, new { style = "font-weight : normal; padding-right : 10px;" }, true)
+                        @Html.CheckBoxFor(x => x.ViewableByProjectSteward) @Html.LabelFor(x => x.ViewableByProjectSteward, new { style = "font-weight : normal; padding-right : 10px;" }, true)
                     </div>
                 </div>
                 <div class="form-group">

--- a/Source/ProjectFirma.Web/Views/ProjectFactSheet/EditFactsheetLogo.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectFactSheet/EditFactsheetLogo.cshtml
@@ -19,6 +19,7 @@ Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*@
 @using LtInfo.Common.Mvc
+@using ProjectFirma.Web.Common
 @inherits ProjectFirma.Web.Views.ProjectFactSheet.EditFactSheetLogo
 
 @using (Html.BeginForm())
@@ -26,7 +27,7 @@ Source code is available upon request via <support@sitkatech.com>.
 <div class="form-horizontal">
     @Html.HiddenFor(m => m.TenantID)
     <div class="form-group">
-        <div class="col-md-4 text-right">@Html.LabelFor(m => m.FactSheetLogoFileResourceData)</div>
+        <div class="col-md-4 text-right">@Html.LabelFor(m => m.FactSheetLogoFileResourceData, true)</div>
         <div class="col-md-8">
             @Html.EditorFor(x => x.FactSheetLogoFileResourceData)
             <span class="smallExplanationText">


### PR DESCRIPTION
@Html.LabelFor was not respecting tenant custom field definition labels. Added overload methods for LabelFor that should be used when using FieldDefinitionDisplay on the property in the ViewModel/ViewData class