### PR TITLE
Fix SearchableDropdownListFor implementation with non-default placeho…

### DIFF
--- a/Source/LtInfo.Common/HtmlHelperExtensions/DropdownForExtensions.cs
+++ b/Source/LtInfo.Common/HtmlHelperExtensions/DropdownForExtensions.cs
@@ -237,6 +237,10 @@ namespace LtInfo.Common.HtmlHelperExtensions
             tagBuilder.MergeAttribute("data-live-search-placeholder", "Search");
             tagBuilder.MergeAttribute("data-container", "body");
             tagBuilder.MergeAttribute("class", "selectpicker");
+            if (optionLabel != null)
+            {
+                tagBuilder.MergeAttribute("title", optionLabel);
+            }
             tagBuilder.GenerateId(fullName);
             if (allowMultiple)
             {
@@ -263,17 +267,6 @@ namespace LtInfo.Common.HtmlHelperExtensions
         private static StringBuilder BuildItems(string optionLabel, IEnumerable<SelectListItem> selectList)
         {
             StringBuilder listItemBuilder = new StringBuilder();
-
-            // Make optionLabel the first item that gets rendered.
-            if (optionLabel != null)
-            {
-                listItemBuilder.AppendLine(EmptyListItemToOption(new SelectListItem()
-                {
-                    Text = optionLabel,
-                    Value = String.Empty,
-                    Selected = false
-                }));
-            }
 
             // Group items in the SelectList if requested.
             // Treat each item with Group == null as a member of a unique group


### PR DESCRIPTION
…lder text. Bootstrap-select pulls placeholder from title property and does not want a placeholder entrly in the select list - this was leading to incorrect value being highlighted in select list.