### PR TITLE
[delta/523] Show primary contact information in full project list

### DIFF
--- a/Database/Objects/Views/dbo.vProjectDetail.sql
+++ b/Database/Objects/Views/dbo.vProjectDetail.sql
@@ -12,7 +12,7 @@ p.ProjectID
 , p.ProjectName
 , po.OrganizationID as PrimaryContactOrganizationID
 , po.DisplayName as PrimaryContactOrganizationDisplayName
-, po.PersonID as PrimaryContactPersonID
+, p.PrimaryContactPersonID
 , case when person.PersonID is not null then person.FirstName + ' ' + person.LastName
     else  po.FullNameFirstLast end as PrimaryContactPersonFullNameFirstLast
 ,  coalesce(person.Email, po.Email) as PrimaryContactPersonEmail


### PR DESCRIPTION
[Related bug card
](https://sitkatech.atlassian.net/browse/DELTA-523)

It appears as though the logic for the primary contact person was being set in conjunction with the organization's primary contact person. I believe it should be pulled directly from the project.