### PR TITLE
Features/2139 rename manage and config pages

### DIFF
--- a/Database/LookupTables/dbo.Role.sql
+++ b/Database/LookupTables/dbo.Role.sql
@@ -1,10 +1,10 @@
 delete from dbo.Role
 go
 
-insert into dbo.Role(RoleID, RoleName, RoleDisplayName, RoleDescription) 
+insert into dbo.Role(RoleID, RoleName, RoleDisplayName, RoleDescription, SortOrder) 
 values 
-(1, 'Admin', 'Administrator', ''),
-(2, 'Normal', 'Normal User', 'Users with this role can propose new EIP projects, update existing EIP projects where their organization is the Lead Implementer, and view almost every page within the EIP Tracker.'),
-(7, 'Unassigned', 'Unassigned', ''),
-(8, 'SitkaAdmin', 'Sitka Administrator', ''),
-(9, 'ProjectSteward', 'Project Steward', 'Users with this role can approve Project Proposals, create new Projects, approve Project Updates, and create Funding Sources for their Organization.')
+(1, 'Admin', 'Administrator', '', 40),
+(2, 'Normal', 'Normal User', 'Users with this role can propose new EIP projects, update existing EIP projects where their organization is the Lead Implementer, and view almost every page within the EIP Tracker.', 20),
+(7, 'Unassigned', 'Unassigned', '', 10),
+(8, 'SitkaAdmin', 'Sitka Administrator', '', 50),
+(9, 'ProjectSteward', 'Project Steward', 'Users with this role can approve Project Proposals, create new Projects, approve Project Updates, and create Funding Sources for their Organization.', 30)

--- a/Database/ReleaseScript/0411 - add SortOrder to Role table.sql
+++ b/Database/ReleaseScript/0411 - add SortOrder to Role table.sql
@@ -1,0 +1,1 @@
+alter table dbo.Role add SortOrder int null

--- a/Database/Tables/dbo.Role.sql
+++ b/Database/Tables/dbo.Role.sql
@@ -7,6 +7,7 @@ CREATE TABLE [dbo].[Role](
 	[RoleName] [varchar](100) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
 	[RoleDisplayName] [varchar](100) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
 	[RoleDescription] [varchar](255) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[SortOrder] [int] NULL,
  CONSTRAINT [PK_Role_RoleID] PRIMARY KEY CLUSTERED 
 (
 	[RoleID] ASC

--- a/Source/ProjectFirma.Web/Models/DocumentLibraryDocumentModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/DocumentLibraryDocumentModelExtensions.cs
@@ -29,7 +29,7 @@ namespace ProjectFirma.Web.Models
         {
             var documentLibraryDocumentRoles = HttpRequestStorage.DatabaseEntities.DocumentLibraryDocumentRoles.Where(x => x.DocumentLibraryDocumentID == documentLibraryDocument.DocumentLibraryDocumentID).ToList();
             return new HtmlString(documentLibraryDocumentRoles.Any()
-                ? string.Join(", ", documentLibraryDocumentRoles.OrderBy(x => x.RoleID).Select(x => x.Role == null ? "Anonymous (Public)" : x.Role.GetRoleDisplayName()).ToList())
+                ? string.Join(", ", documentLibraryDocumentRoles.OrderBy(x => x.Role?.SortOrder).Select(x => x.Role == null ? "Anonymous (Public)" : x.Role.GetRoleDisplayName()).ToList())
                 : ViewUtilities.NoAnswerProvided);
         }
 

--- a/Source/ProjectFirma.Web/Models/FundingSourceCustomAttributeTypeModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/FundingSourceCustomAttributeTypeModelExtensions.cs
@@ -35,7 +35,7 @@ namespace ProjectFirma.Web.Models
         {
             var customAttributeTypeEditableRoles = HttpRequestStorage.DatabaseEntities.FundingSourceCustomAttributeTypeRoles.Where(x => x.FundingSourceCustomAttributeTypeID == fundingSourceCustomAttributeType.FundingSourceCustomAttributeTypeID).ToList();
             return new HtmlString(customAttributeTypeEditableRoles.Any()
-                ? String.Join(", ", customAttributeTypeEditableRoles.OrderBy(x => x.RoleID).Where(x => x.FundingSourceCustomAttributeTypeRolePermissionType == FundingSourceCustomAttributeTypeRolePermissionType.Edit).Select(x => x.Role.GetRoleDisplayName()).ToList())
+                ? String.Join(", ", customAttributeTypeEditableRoles.OrderBy(x => x.Role?.SortOrder).Where(x => x.FundingSourceCustomAttributeTypeRolePermissionType == FundingSourceCustomAttributeTypeRolePermissionType.Edit).Select(x => x.Role.GetRoleDisplayName()).ToList())
                 : ViewUtilities.NoAnswerProvided);
         }
 
@@ -43,7 +43,7 @@ namespace ProjectFirma.Web.Models
         {
             var customAttributeTypViewableRoles = HttpRequestStorage.DatabaseEntities.FundingSourceCustomAttributeTypeRoles.Where(x => x.FundingSourceCustomAttributeTypeID == fundingSourceCustomAttributeType.FundingSourceCustomAttributeTypeID).ToList();
             return new HtmlString(customAttributeTypViewableRoles.Any()
-                ? String.Join(", ", customAttributeTypViewableRoles.OrderBy(x => x.RoleID).Where(x => x.FundingSourceCustomAttributeTypeRolePermissionType == FundingSourceCustomAttributeTypeRolePermissionType.View).Select(x => x.Role.GetRoleDisplayName()).ToList())
+                ? String.Join(", ", customAttributeTypViewableRoles.OrderBy(x => x.Role?.SortOrder).Where(x => x.FundingSourceCustomAttributeTypeRolePermissionType == FundingSourceCustomAttributeTypeRolePermissionType.View).Select(x => x.Role.GetRoleDisplayName()).ToList())
                 : ViewUtilities.NoAnswerProvided);
         }
 

--- a/Source/ProjectFirma.Web/Models/ProjectCustomAttributeTypeModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectCustomAttributeTypeModelExtensions.cs
@@ -35,7 +35,7 @@ namespace ProjectFirma.Web.Models
         {
             var customAttributeTypeEditableRoles = HttpRequestStorage.DatabaseEntities.ProjectCustomAttributeTypeRoles.Where(x => x.ProjectCustomAttributeTypeID == projectCustomAttributeType.ProjectCustomAttributeTypeID).ToList();
             return new HtmlString(customAttributeTypeEditableRoles.Any() 
-                ? String.Join(", ", customAttributeTypeEditableRoles.OrderBy(x => x.RoleID).Where(x => x.ProjectCustomAttributeTypeRolePermissionType == ProjectCustomAttributeTypeRolePermissionType.Edit).Select(x => x.Role.GetRoleDisplayName()).ToList()) 
+                ? String.Join(", ", customAttributeTypeEditableRoles.OrderBy(x => x.Role?.SortOrder).Where(x => x.ProjectCustomAttributeTypeRolePermissionType == ProjectCustomAttributeTypeRolePermissionType.Edit).Select(x => x.Role.GetRoleDisplayName()).ToList()) 
                 : ViewUtilities.NoAnswerProvided);
         }
 
@@ -43,7 +43,7 @@ namespace ProjectFirma.Web.Models
         {
             var customAttributeTypViewableRoles = HttpRequestStorage.DatabaseEntities.ProjectCustomAttributeTypeRoles.Where(x => x.ProjectCustomAttributeTypeID == projectCustomAttributeType.ProjectCustomAttributeTypeID).ToList();
             return new HtmlString(customAttributeTypViewableRoles.Any()
-                ? String.Join(", ", customAttributeTypViewableRoles.OrderBy(x => x.RoleID).Where(x => x.ProjectCustomAttributeTypeRolePermissionType == ProjectCustomAttributeTypeRolePermissionType.View).Select(x => x.Role == null ? "Anonymous (Public)" : x.Role.GetRoleDisplayName()).ToList())
+                ? String.Join(", ", customAttributeTypViewableRoles.OrderBy(x => x.Role?.SortOrder).Where(x => x.ProjectCustomAttributeTypeRolePermissionType == ProjectCustomAttributeTypeRolePermissionType.View).Select(x => x.Role == null ? "Anonymous (Public)" : x.Role.GetRoleDisplayName()).ToList())
                 : ViewUtilities.NoAnswerProvided);
         }
 

--- a/Source/ProjectFirma.Web/Views/FieldDefinition/IndexViewData.cs
+++ b/Source/ProjectFirma.Web/Views/FieldDefinition/IndexViewData.cs
@@ -39,7 +39,7 @@ namespace ProjectFirma.Web.Views.FieldDefinition
 
         public IndexViewData(FirmaSession currentFirmaSession) : base(currentFirmaSession)
         {
-            PageTitle = "Field Definitions";
+            PageTitle = "Labels & Definitions";
 
             GridSpec = new FieldDefinitionGridSpec(new FieldDefinitionViewListFeature().HasPermissionByFirmaSession(currentFirmaSession))
             {

--- a/Source/ProjectFirmaModels/Models/Generated/Role.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/Role.Binding.cs
@@ -39,12 +39,13 @@ namespace ProjectFirmaModels.Models
         /// <summary>
         /// Protected constructor only for use in instantiating the set of static lookup values that match database
         /// </summary>
-        protected Role(int roleID, string roleName, string roleDisplayName, string roleDescription)
+        protected Role(int roleID, string roleName, string roleDisplayName, string roleDescription, int? sortOrder)
         {
             RoleID = roleID;
             RoleName = roleName;
             RoleDisplayName = roleDisplayName;
             RoleDescription = roleDescription;
+            SortOrder = sortOrder;
         }
 
         [Key]
@@ -52,6 +53,7 @@ namespace ProjectFirmaModels.Models
         public string RoleName { get; private set; }
         public string RoleDisplayName { get; private set; }
         public string RoleDescription { get; private set; }
+        public int? SortOrder { get; private set; }
         [NotMapped]
         public int PrimaryKey { get { return RoleID; } }
 
@@ -131,31 +133,31 @@ namespace ProjectFirmaModels.Models
 
     public partial class RoleAdmin : Role
     {
-        private RoleAdmin(int roleID, string roleName, string roleDisplayName, string roleDescription) : base(roleID, roleName, roleDisplayName, roleDescription) {}
-        public static readonly RoleAdmin Instance = new RoleAdmin(1, @"Admin", @"Administrator", @"");
+        private RoleAdmin(int roleID, string roleName, string roleDisplayName, string roleDescription, int? sortOrder) : base(roleID, roleName, roleDisplayName, roleDescription, sortOrder) {}
+        public static readonly RoleAdmin Instance = new RoleAdmin(1, @"Admin", @"Administrator", @"", 40);
     }
 
     public partial class RoleNormal : Role
     {
-        private RoleNormal(int roleID, string roleName, string roleDisplayName, string roleDescription) : base(roleID, roleName, roleDisplayName, roleDescription) {}
-        public static readonly RoleNormal Instance = new RoleNormal(2, @"Normal", @"Normal User", @"Users with this role can propose new EIP projects, update existing EIP projects where their organization is the Lead Implementer, and view almost every page within the EIP Tracker.");
+        private RoleNormal(int roleID, string roleName, string roleDisplayName, string roleDescription, int? sortOrder) : base(roleID, roleName, roleDisplayName, roleDescription, sortOrder) {}
+        public static readonly RoleNormal Instance = new RoleNormal(2, @"Normal", @"Normal User", @"Users with this role can propose new EIP projects, update existing EIP projects where their organization is the Lead Implementer, and view almost every page within the EIP Tracker.", 20);
     }
 
     public partial class RoleUnassigned : Role
     {
-        private RoleUnassigned(int roleID, string roleName, string roleDisplayName, string roleDescription) : base(roleID, roleName, roleDisplayName, roleDescription) {}
-        public static readonly RoleUnassigned Instance = new RoleUnassigned(7, @"Unassigned", @"Unassigned", @"");
+        private RoleUnassigned(int roleID, string roleName, string roleDisplayName, string roleDescription, int? sortOrder) : base(roleID, roleName, roleDisplayName, roleDescription, sortOrder) {}
+        public static readonly RoleUnassigned Instance = new RoleUnassigned(7, @"Unassigned", @"Unassigned", @"", 10);
     }
 
     public partial class RoleSitkaAdmin : Role
     {
-        private RoleSitkaAdmin(int roleID, string roleName, string roleDisplayName, string roleDescription) : base(roleID, roleName, roleDisplayName, roleDescription) {}
-        public static readonly RoleSitkaAdmin Instance = new RoleSitkaAdmin(8, @"SitkaAdmin", @"Sitka Administrator", @"");
+        private RoleSitkaAdmin(int roleID, string roleName, string roleDisplayName, string roleDescription, int? sortOrder) : base(roleID, roleName, roleDisplayName, roleDescription, sortOrder) {}
+        public static readonly RoleSitkaAdmin Instance = new RoleSitkaAdmin(8, @"SitkaAdmin", @"Sitka Administrator", @"", 50);
     }
 
     public partial class RoleProjectSteward : Role
     {
-        private RoleProjectSteward(int roleID, string roleName, string roleDisplayName, string roleDescription) : base(roleID, roleName, roleDisplayName, roleDescription) {}
-        public static readonly RoleProjectSteward Instance = new RoleProjectSteward(9, @"ProjectSteward", @"Project Steward", @"Users with this role can approve Project Proposals, create new Projects, approve Project Updates, and create Funding Sources for their Organization.");
+        private RoleProjectSteward(int roleID, string roleName, string roleDisplayName, string roleDescription, int? sortOrder) : base(roleID, roleName, roleDisplayName, roleDescription, sortOrder) {}
+        public static readonly RoleProjectSteward Instance = new RoleProjectSteward(9, @"ProjectSteward", @"Project Steward", @"Users with this role can approve Project Proposals, create new Projects, approve Project Updates, and create Funding Sources for their Organization.", 30);
     }
 }


### PR DESCRIPTION
Rework:
- fixed PageTitle for Field Definition index page to match menu item
- added SortOrder to Role table so lists of editable by or viewable roles (in grids) display the roles in the order that matches the modal editors (e.g. Unassigned before Normal User)