### PR TITLE
Features/2138 rework

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/TenantController.cs
+++ b/Source/ProjectFirma.Web/Controllers/TenantController.cs
@@ -214,7 +214,8 @@ namespace ProjectFirma.Web.Controllers
         [SitkaAdminFeature]
         public PartialViewResult EditStylesheet()
         {
-            var viewModel = new EditStylesheetViewModel();
+            var tenant = HttpRequestStorage.Tenant;
+            var viewModel = new EditStylesheetViewModel(tenant);
             return ViewEditStylesheet(viewModel);
         }
 
@@ -228,8 +229,8 @@ namespace ProjectFirma.Web.Controllers
                 return ViewEditStylesheet(viewModel);
             }
 
-            var tenantAttribute = MultiTenantHelpers.GetTenantAttributeFromCache();
-            viewModel.UpdateModel(tenantAttribute, CurrentFirmaSession);
+            var tenantAttribute = HttpRequestStorage.DatabaseEntities.AllTenantAttributes.Single(a => a.TenantID == viewModel.TenantID);
+            viewModel.UpdateModel(tenantAttribute, CurrentFirmaSession, HttpRequestStorage.DatabaseEntities);
             MultiTenantHelpers.ClearTenantAttributeCacheForAllTenants();
             return new ModalDialogFormJsonResult(new SitkaRoute<TenantController>(c => c.Detail()).BuildUrlFromExpression());
         }
@@ -383,14 +384,20 @@ namespace ProjectFirma.Web.Controllers
         [AutomaticallyCallEntityFrameworkSaveChangesWhenModelValid]
         public ActionResult DeleteTenantBannerLogoFileResource(ConfirmDialogFormViewModel viewModel)
         {
-            var tenantAttribute = MultiTenantHelpers.GetTenantAttributeFromCache();
+            var tenantAttribute = HttpRequestStorage.DatabaseEntities.AllTenantAttributes.Single(a => a.TenantID == HttpRequestStorage.DatabaseEntities.TenantID);
             if (!ModelState.IsValid)
             {
                 return ViewDeleteTenantBannerLogoFileResource(viewModel, tenantAttribute);
             }
 
             var tenantAttributeTenantBannerLogoFileResource = tenantAttribute.TenantBannerLogoFileResourceInfo;
+            var fileResourceDatas = tenantAttribute.TenantBannerLogoFileResourceInfo.FileResourceDatas;
+            tenantAttribute.TenantBannerLogoFileResourceInfo.FileResourceDatas = null;
             tenantAttribute.TenantBannerLogoFileResourceInfo = null;
+            foreach (var fileResourceData in fileResourceDatas)
+            {
+                fileResourceData.Delete(HttpRequestStorage.DatabaseEntities);
+            }
             tenantAttributeTenantBannerLogoFileResource.Delete(HttpRequestStorage.DatabaseEntities);
             MultiTenantHelpers.ClearTenantAttributeCacheForAllTenants();
             return new ModalDialogFormJsonResult();
@@ -418,15 +425,20 @@ namespace ProjectFirma.Web.Controllers
         [AutomaticallyCallEntityFrameworkSaveChangesWhenModelValid]
         public ActionResult DeleteTenantSquareLogoFileResource(ConfirmDialogFormViewModel viewModel)
         {
-            var tenant = HttpRequestStorage.Tenant;
-            var tenantAttribute = MultiTenantHelpers.GetTenantAttributeFromCache();
+            var tenantAttribute = HttpRequestStorage.DatabaseEntities.AllTenantAttributes.Single(a => a.TenantID == HttpRequestStorage.DatabaseEntities.TenantID);
             if (!ModelState.IsValid)
             {
                 return ViewDeleteTenantSquareLogoFileResource(viewModel, tenantAttribute);
             }
 
             var tenantAttributeTenantSquareLogoFileResource = tenantAttribute.TenantSquareLogoFileResourceInfo;
+            var fileResourceDatas = tenantAttribute.TenantSquareLogoFileResourceInfo.FileResourceDatas;
+            tenantAttribute.TenantSquareLogoFileResourceInfo.FileResourceDatas = null;
             tenantAttribute.TenantSquareLogoFileResourceInfo = null;
+            foreach (var fileResourceData in fileResourceDatas)
+            {
+                fileResourceData.Delete(HttpRequestStorage.DatabaseEntities);
+            }
             tenantAttributeTenantSquareLogoFileResource.Delete(HttpRequestStorage.DatabaseEntities);
             MultiTenantHelpers.ClearTenantAttributeCacheForAllTenants();
             return new ModalDialogFormJsonResult();
@@ -454,15 +466,20 @@ namespace ProjectFirma.Web.Controllers
         [AutomaticallyCallEntityFrameworkSaveChangesWhenModelValid]
         public ActionResult DeleteTenantStyleSheetFileResource(ConfirmDialogFormViewModel viewModel)
         {
-            var tenant = HttpRequestStorage.Tenant;
-            var tenantAttribute = MultiTenantHelpers.GetTenantAttributeFromCache();
+            var tenantAttribute = HttpRequestStorage.DatabaseEntities.AllTenantAttributes.Single(a => a.TenantID == HttpRequestStorage.DatabaseEntities.TenantID);
             if (!ModelState.IsValid)
             {
                 return ViewDeleteTenantStyleSheetFileResource(viewModel, tenantAttribute);
             }
 
             var tenantAttributeTenantStyleSheetFileResource = tenantAttribute.TenantStyleSheetFileResourceInfo;
+            var fileResourceDatas = tenantAttribute.TenantStyleSheetFileResourceInfo.FileResourceDatas;
+            tenantAttribute.TenantStyleSheetFileResourceInfo.FileResourceDatas = null;
             tenantAttribute.TenantStyleSheetFileResourceInfo = null;
+            foreach (var fileResourceData in fileResourceDatas)
+            {
+                fileResourceData.Delete(HttpRequestStorage.DatabaseEntities);
+            }
             tenantAttributeTenantStyleSheetFileResource.Delete(HttpRequestStorage.DatabaseEntities);
             MultiTenantHelpers.ClearTenantAttributeCacheForAllTenants();
             return new ModalDialogFormJsonResult();

--- a/Source/ProjectFirma.Web/Views/Tenant/EditStylesheet.cshtml
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditStylesheet.cshtml
@@ -26,6 +26,7 @@ Source code is available upon request via <support@sitkatech.com>.
 @using (Html.BeginForm())
 {
 <div class="form-horizontal">
+    @Html.HiddenFor(m => m.TenantID)
     <div class="form-group">
         <div class="col-md-4 text-right">@Html.LabelWithSugarFor(m => m.TenantStyleSheetFileResourceData)</div>
         <div class="col-md-8">

--- a/Source/ProjectFirma.Web/Views/Tenant/EditStylesheetViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditStylesheetViewModel.cs
@@ -31,7 +31,10 @@ using ProjectFirmaModels.Models;
 namespace ProjectFirma.Web.Views.Tenant
 {
     public class EditStylesheetViewModel : FormViewModel
-    {        
+    {
+        [Required]
+        public int? TenantID { get; set; }
+
         [DisplayName("Tenant Style Sheet")]
         [SitkaFileExtensions("css")]
         [Required]
@@ -46,9 +49,17 @@ namespace ProjectFirma.Web.Views.Tenant
         {
         }
 
-        public void UpdateModel(TenantAttribute tenantAttribute, FirmaSession currentFirmaSession)
+        public EditStylesheetViewModel(ProjectFirmaModels.Models.Tenant tenant)
         {
-           tenantAttribute.TenantStyleSheetFileResourceInfo = FileResourceModelExtensions.CreateNewFromHttpPostedFileAndSave(TenantStyleSheetFileResourceData, currentFirmaSession);
+            TenantID = tenant.TenantID;
+        }
+
+        public void UpdateModel(TenantAttribute tenantAttribute, FirmaSession currentFirmaSession, DatabaseEntities databaseEntities)
+        {
+            var attributeTenantStyleSheetFileResource = tenantAttribute.TenantSquareLogoFileResourceInfo;
+            tenantAttribute.TenantStyleSheetFileResourceInfo = FileResourceModelExtensions.CreateNewFromHttpPostedFileAndSave(TenantStyleSheetFileResourceData, currentFirmaSession);
+            attributeTenantStyleSheetFileResource?.FileResourceData.Delete(databaseEntities);
+            attributeTenantStyleSheetFileResource?.Delete(databaseEntities);
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogoViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/Tenant/EditTenantLogoViewModel.cs
@@ -64,12 +64,14 @@ namespace ProjectFirma.Web.Views.Tenant
             {
                 var attributeTenantSquareLogoFileResource = tenantAttribute.TenantSquareLogoFileResourceInfo;
                 tenantAttribute.TenantSquareLogoFileResourceInfo = FileResourceModelExtensions.CreateNewFromHttpPostedFileAndSave(TenantSquareLogoFileResourceData, currentFirmaSession);
+                attributeTenantSquareLogoFileResource?.FileResourceData.Delete(databaseEntities);
                 attributeTenantSquareLogoFileResource?.Delete(databaseEntities);
             }
             if (TenantBannerLogoFileResourceData != null)
             {
                 var attributeTenantBannerLogoFileResource = tenantAttribute.TenantBannerLogoFileResourceInfo;
                 tenantAttribute.TenantBannerLogoFileResourceInfo = FileResourceModelExtensions.CreateNewFromHttpPostedFileAndSave(TenantBannerLogoFileResourceData, currentFirmaSession);
+                attributeTenantBannerLogoFileResource?.FileResourceData.Delete(databaseEntities);
                 attributeTenantBannerLogoFileResource?.Delete(databaseEntities);
             }
         }


### PR DESCRIPTION
bug fix: need to load the Tenant Attribute from the database (not the cache) when deleting a logo or style sheet (otherwise throws 'not found in the ObjectStateManager' exception). Also fixed bug with editing style sheet (previously it would save the new file resource, but not actually update the tenant attribute table because it was loaded from the cache). Made sure to delete old file resources when editing.