### PR TITLE
PF-2197: prevent normal user clicking other users' detail page hyperlink

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/ProjectController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectController.cs
@@ -202,10 +202,10 @@ namespace ProjectFirma.Web.Controllers
                 userHasEditProjectPermissions);
             var entityExternalLinksViewData = new EntityExternalLinksViewData(ExternalLink.CreateFromEntityExternalLink(new List<IEntityExternalLink>(project.ProjectExternalLinks)));
 
-            var auditLogsGridSpec = new AuditLogsGridSpec {ObjectNameSingular = "Change", ObjectNamePlural = "Changes", SaveFiltersInCookie = true};
+            var auditLogsGridSpec = new AuditLogsGridSpec(CurrentFirmaSession) {ObjectNameSingular = "Change", ObjectNamePlural = "Changes", SaveFiltersInCookie = true};
             var auditLogsGridDataUrl = SitkaRoute<ProjectController>.BuildUrlFromExpression(tc => tc.AuditLogsGridJsonData(project));
 
-            var projectNotificationGridSpec = new ProjectNotificationGridSpec();
+            var projectNotificationGridSpec = new ProjectNotificationGridSpec(CurrentFirmaSession);
             const string projectNotificationGridName = "projectNotifications";
             var projectNotificationGridDataUrl = SitkaRoute<ProjectController>.BuildUrlFromExpression(tc => tc.ProjectNotificationsGridJsonData(project));
 
@@ -757,7 +757,7 @@ namespace ProjectFirma.Web.Controllers
         [FirmaAdminFeature]
         public GridJsonNetJObjectResult<AuditLog> AuditLogsGridJsonData(ProjectPrimaryKey projectPrimaryKey)
         {
-            var gridSpec = new AuditLogsGridSpec();
+            var gridSpec = new AuditLogsGridSpec(CurrentFirmaSession);
             var auditLogs = HttpRequestStorage.DatabaseEntities.AuditLogs.GetAuditLogEntriesForProject(projectPrimaryKey.EntityObject).OrderByDescending(x => x.AuditLogDate).ToList();
             var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<AuditLog>(auditLogs, gridSpec);
             return gridJsonNetJObjectResult;
@@ -913,7 +913,7 @@ Continue with a new {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabe
         public GridJsonNetJObjectResult<Notification> ProjectNotificationsGridJsonData(ProjectPrimaryKey projectPrimaryKey)
         {
             var project = projectPrimaryKey.EntityObject;
-            var gridSpec = new ProjectNotificationGridSpec();
+            var gridSpec = new ProjectNotificationGridSpec(CurrentFirmaSession);
             var notifications = project.NotificationProjects.Select(x => x.Notification).OrderByDescending(x => x.NotificationDate).ToList();
             var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<Notification>(notifications, gridSpec);
             return gridJsonNetJObjectResult;

--- a/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
@@ -1609,7 +1609,7 @@ namespace ProjectFirma.Web.Controllers
         [ProjectViewFeature]
         public GridJsonNetJObjectResult<AuditLog> AuditLogsGridJsonData(ProjectPrimaryKey projectPrimaryKey)
         {
-            var gridSpec = new AuditLogsGridSpec();
+            var gridSpec = new AuditLogsGridSpec(CurrentFirmaSession);
             var auditLogs = HttpRequestStorage.DatabaseEntities.AuditLogs.GetAuditLogEntriesForProject(projectPrimaryKey.EntityObject);
             var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<AuditLog>(auditLogs, gridSpec);
             return gridJsonNetJObjectResult;

--- a/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
@@ -175,7 +175,7 @@ namespace ProjectFirma.Web.Controllers
         [LoggedInAndNotUnassignedRoleUnclassifiedFeature]
         public GridJsonNetJObjectResult<Project> IndexGridJsonData(ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum projectUpdateStatusFilterType)
         {
-            var gridSpec = new ProjectUpdateStatusGridSpec(projectUpdateStatusFilterType, CurrentPerson.IsApprover());
+            var gridSpec = new ProjectUpdateStatusGridSpec(CurrentFirmaSession, projectUpdateStatusFilterType, CurrentPerson.IsApprover());
             var projects = HttpRequestStorage.DatabaseEntities.Projects.ToList().GetActiveProjects().Where(p => p.IsUpdatableViaProjectUpdateProcess());
 
             switch (projectUpdateStatusFilterType)
@@ -2264,7 +2264,7 @@ namespace ProjectFirma.Web.Controllers
         public ViewResult Manage()
         {
             var customNotificationUrl = SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.CreateCustomNotification(null));
-            var projectsRequiringUpdateGridSpec = new ProjectUpdateStatusGridSpec(ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.AllProjects, CurrentPerson.IsApprover())
+            var projectsRequiringUpdateGridSpec = new ProjectUpdateStatusGridSpec(CurrentFirmaSession, ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.AllProjects, CurrentPerson.IsApprover())
             {
                 ObjectNameSingular = $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()}",
                 ObjectNamePlural = $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}",
@@ -2296,7 +2296,7 @@ namespace ProjectFirma.Web.Controllers
         [ProjectUpdateAdminFeature]
         public GridJsonNetJObjectResult<Project> ProjectsRequiringUpdateGridJsonData()
         {
-            var gridSpec = new ProjectUpdateStatusGridSpec(ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.AllProjects, CurrentPerson.IsApprover());
+            var gridSpec = new ProjectUpdateStatusGridSpec(CurrentFirmaSession, ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.AllProjects, CurrentPerson.IsApprover());
             var projects =
                 HttpRequestStorage.DatabaseEntities.Projects.ToList().GetActiveProjects().Where(x => x.IsUpdatableViaProjectUpdateProcess() && x.IsEditableToThisFirmaSession(CurrentFirmaSession)).ToList();
             var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<Project>(projects, gridSpec);

--- a/Source/ProjectFirma.Web/Controllers/UserController.cs
+++ b/Source/ProjectFirma.Web/Controllers/UserController.cs
@@ -453,7 +453,7 @@ namespace ProjectFirma.Web.Controllers
             var existingUser = HttpRequestStorage.DatabaseEntities.People.GetPersonByPersonGuid(keystoneUser.UserGuid);
             if (existingUser != null)
             {
-                SetMessageForDisplay($"{existingUser.GetFullNameFirstLastAndOrgAsUrl()} already has an account.</a>.");
+                SetMessageForDisplay($"{existingUser.GetFullNameFirstLastAndOrgAsUrl(CurrentFirmaSession)} already has an account.</a>.");
                 return RedirectToAction(new SitkaRoute<UserController>(x => x.Detail(existingUser)));
             }
 
@@ -471,7 +471,7 @@ namespace ProjectFirma.Web.Controllers
             }
 
             SetMessageForDisplay(
-                $"{newUser.GetFullNameFirstLastAndOrgAsUrl()} successfully added. You may want to assign them a role</a>.");
+                $"{newUser.GetFullNameFirstLastAndOrgAsUrl(CurrentFirmaSession)} successfully added. You may want to assign them a role</a>.");
             return RedirectToAction(new SitkaRoute<UserController>(x => x.Detail(newUser)));
         }
 

--- a/Source/ProjectFirma.Web/Models/OrganizationModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/OrganizationModelExtensions.cs
@@ -305,19 +305,12 @@ namespace ProjectFirma.Web.Models
             return geoJsons.Select(x => new OrganizationBoundaryStaging(organization, x.Key, x.Value)).ToList();
         }
 
-        public static HtmlString GetPrimaryContactPersonAsUrl(this Organization organization) => organization.PrimaryContactPerson != null
-            ? organization.PrimaryContactPerson.GetFullNameFirstLastAsUrl()
+        public static HtmlString GetPrimaryContactPersonAsUrl(this Organization organization, FirmaSession currentFirmaSession) => organization.PrimaryContactPerson != null
+            ? organization.PrimaryContactPerson.GetFullNameFirstLastAsUrl(currentFirmaSession)
             : new HtmlString(ViewUtilities.NoneString);
 
-        public static HtmlString GetPrimaryContactPersonWithOrgAsUrl(this Organization organization) => organization.PrimaryContactPerson != null
-            ? organization.PrimaryContactPerson.GetFullNameFirstLastAndOrgAsUrl()
-            : new HtmlString(ViewUtilities.NoneString);
-
-        /// <summary>
-        /// Use for security situations where the user summary is not displayable, but the Organization is.
-        /// </summary>
-        public static HtmlString GetPrimaryContactPersonAsStringAndOrgAsUrl(this Organization organization) => organization.PrimaryContactPerson != null
-            ? organization.PrimaryContactPerson.GetFullNameFirstLastAsStringAndOrgAsUrl()
+        public static HtmlString GetPrimaryContactPersonWithOrgAsUrl(this Organization organization, FirmaSession currentFirmaSession) => organization.PrimaryContactPerson != null
+            ? organization.PrimaryContactPerson.GetFullNameFirstLastAndOrgAsUrl(currentFirmaSession)
             : new HtmlString(ViewUtilities.NoneString);
 
         public static string GetPrimaryContactPersonWithOrgAsString(this Organization organization) => organization.PrimaryContactPerson != null

--- a/Source/ProjectFirma.Web/Models/PersonModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/PersonModelExtensions.cs
@@ -38,30 +38,27 @@ namespace ProjectFirma.Web.Models
     /// </summary>
     public static class PersonModelExtensions
     {
-        public static HtmlString GetFullNameFirstLastAsUrl(this Person person)
+        public static HtmlString GetFullNameFirstLastAsUrl(this Person person, FirmaSession currentFirmaSession)
         {
-            return UrlTemplate.MakeHrefString(person.GetDetailUrl(), person.GetFullNameFirstLast());
+            if (new UserViewFeature().HasPermission(currentFirmaSession, person).HasPermission)
+            {
+                return UrlTemplate.MakeHrefString(person.GetDetailUrl(), person.GetFullNameFirstLast());
+            }
+            return new HtmlString(person.GetFullNameFirstLast());
         }
 
-        public static HtmlString GetFullNameFirstLastAndOrgAsUrl(this Person person)
+        public static HtmlString GetFullNameFirstLastAndOrgAsUrl(this Person person, FirmaSession currentFirmaSession)
         {
-            var userUrl = person.GetFullNameFirstLastAsUrl();
+            var userUrl = person.GetFullNameFirstLastAsUrl(currentFirmaSession);
             var orgUrl = person.Organization.GetDisplayNameAsUrl();
             return new HtmlString($"{userUrl} - {orgUrl}");
         }
 
-        public static HtmlString GetFullNameFirstLastAndOrgShortNameAsUrl(this Person person)
+        public static HtmlString GetFullNameFirstLastAndOrgShortNameAsUrl(this Person person, FirmaSession currentFirmaSession)
         {
-            var userUrl = person.GetFullNameFirstLastAsUrl();
+            var userUrl = person.GetFullNameFirstLastAsUrl(currentFirmaSession);
             var orgUrl = person.Organization.GetShortNameAsUrl();
             return new HtmlString($"{userUrl} ({orgUrl})");
-        }
-
-        public static HtmlString GetFullNameFirstLastAsStringAndOrgAsUrl(this Person person)
-        {
-            var userString = person.GetFullNameFirstLast();
-            var orgUrl = person.Organization.GetShortNameAsUrl();
-            return new HtmlString($"{userString} - {orgUrl}");
         }
 
         public static string GetFullNameFirstLastAndOrg(this Person person) => $"{person.FirstName} {person.LastName} - {person.Organization.GetDisplayName()}";

--- a/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
@@ -157,7 +157,7 @@
                                                 {
                                                     <span style="margin-right: 5px">@ModalDialogFormHelper.MakeEditIconLink(ViewDataTyped.EditOrganizationPrimaryContactUrl, string.Format("Edit {0} for {1}", FieldDefinitionEnum.OrganizationPrimaryContact.ToType().FieldDefinitionDisplayName, ViewDataTyped.Organization.OrganizationName), 800, ViewDataTyped.UserHasOrganizationManagePrimaryContactPermissions)</span>
                                                 }
-                                                @(new UserViewFeature().HasPermission(ViewDataTyped.CurrentFirmaSession, ViewDataTyped.Organization.PrimaryContactPerson).HasPermission ? ViewDataTyped.Organization.GetPrimaryContactPersonWithOrgAsUrl() : ViewDataTyped.Organization.GetPrimaryContactPersonAsStringAndOrgAsUrl())
+                                                @ViewDataTyped.Organization.GetPrimaryContactPersonWithOrgAsUrl(ViewDataTyped.CurrentFirmaSession)
                                             </div>
                                         </div>
                                     </div>
@@ -333,18 +333,9 @@
                                     <ul>
                                         @foreach (var person in ViewDataTyped.Organization.People.Where(x => x.IsActive).OrderBy(x => x.GetFullNameLastFirst()))
                                         {
-                                            if (new UserViewFeature().HasPermission(ViewDataTyped.CurrentFirmaSession, person).HasPermission)
-                                            {
-                                                <li>
-                                                    @person.GetFullNameFirstLastAsUrl()
-                                                </li>
-                                            }
-                                            else
-                                            {
-                                                <li>
-                                                    @person.GetFullNameFirstLast()
-                                                </li>
-                                            }
+                                            <li>
+                                                @person.GetFullNameFirstLastAsUrl(ViewDataTyped.CurrentFirmaSession)
+                                            </li>
                                         }
                                     </ul>
                                 }

--- a/Source/ProjectFirma.Web/Views/Organization/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/IndexGridSpec.cs
@@ -20,9 +20,7 @@ Source code is available upon request via <support@sitkatech.com>.
 -----------------------------------------------------------------------*/
 
 using System.Linq;
-using System.Web;
 using ProjectFirmaModels.Models;
-using ProjectFirma.Web.Security;
 using LtInfo.Common;
 using LtInfo.Common.DhtmlWrappers;
 using LtInfo.Common.Views;
@@ -49,7 +47,6 @@ namespace ProjectFirma.Web.Views.Organization
                 .GroupBy(x => x.OrganizationID)
                 .ToDictionary(x => x.Key, y => y.ToList());
 
-            var userViewFeature = new UserViewFeature();
             if (hasDeletePermissions)
             {
                 Add(string.Empty, x => DhtmlxGridHtmlHelpers.MakeDeleteIconAndLinkBootstrap(x.GetDeleteUrl(), true), 30, DhtmlxGridColumnFilterType.None);
@@ -57,7 +54,7 @@ namespace ProjectFirma.Web.Views.Organization
             Add(FieldDefinitionEnum.Organization.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.OrganizationName), 400, DhtmlxGridColumnFilterType.Html);
             Add("Short Name", a => a.OrganizationShortName, 100);
             Add(FieldDefinitionEnum.OrganizationType.ToType().ToGridHeaderString(), a => a.OrganizationType?.OrganizationTypeName, 100, DhtmlxGridColumnFilterType.SelectFilterStrict);
-            Add(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().ToGridHeaderString(), a => userViewFeature.HasPermission(currentFirmaSession, a.PrimaryContactPerson).HasPermission ? a.GetPrimaryContactPersonAsUrl() : new HtmlString(a.GetPrimaryContactPersonAsString()), 120);
+            Add(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().ToGridHeaderString(), a => a.GetPrimaryContactPersonAsUrl(currentFirmaSession), 120);
             Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} associated with this {FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()}", a => a.GetAllActiveProjects(fundingSourceDictionary, projectFundingSourceBudgetsDictionary, projectFundingSourceExpenditureDictionary, projectDictionary).Count, 90);
             if (currentFirmaSession.Person.CanViewProposals())
             {

--- a/Source/ProjectFirma.Web/Views/Project/PendingGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/PendingGridSpec.cs
@@ -60,7 +60,7 @@ namespace ProjectFirma.Web.Views.Project
             Add(FieldDefinitionEnum.SecuredFunding.ToType().ToGridHeaderString(), x => x.GetSecuredFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.TargetedFunding.ToType().ToGridHeaderString(), x => x.GetTargetedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedAmount(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
-            Add("Submitted By", a => a.SubmittedByPerson != null ? a.SubmittedByPerson.GetFullNameFirstLastAndOrgShortNameAsUrl() : new HtmlString(null), 200);
+            Add("Submitted By", a => a.SubmittedByPerson != null ? a.SubmittedByPerson.GetFullNameFirstLastAndOrgShortNameAsUrl(currentFirmaSession) : new HtmlString(null), 200);
             Add("Submitted Date", a => a.SubmissionDate, 120);
             Add("Last Updated", a => a.LastUpdatedDate, 120);
             Add(FieldDefinitionEnum.ProjectDescription.ToType().ToGridHeaderString(), x => x.ProjectDescription, 300);

--- a/Source/ProjectFirma.Web/Views/Project/ProjectNotificationGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ProjectNotificationGridSpec.cs
@@ -21,17 +21,18 @@ Source code is available upon request via <support@sitkatech.com>.
 using LtInfo.Common.DhtmlWrappers;
 using LtInfo.Common.Views;
 using ProjectFirma.Web.Models;
+using ProjectFirmaModels.Models;
 
 namespace ProjectFirma.Web.Views.Project
 {
     public class ProjectNotificationGridSpec : GridSpec<ProjectFirmaModels.Models.Notification>
     {
-        public ProjectNotificationGridSpec()
+        public ProjectNotificationGridSpec(FirmaSession currentFirmaSession)
         {
             Add("Date", x => x.NotificationDate, 120);
             Add("Notification Type", x => x.NotificationType.NotificationTypeDisplayName, 140, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add("Notification", x => x.NotificationType.GetFullDescriptionFromProjectPerspective(), 400, DhtmlxGridColumnFilterType.SelectFilterStrict);
-            Add("Person Notified", x => x.Person.GetFullNameFirstLastAndOrgAsUrl(), 400);
+            Add("Person Notified", x => x.Person.GetFullNameFirstLastAndOrgAsUrl(currentFirmaSession), 400);
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Project/ProposalsGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ProposalsGridSpec.cs
@@ -19,7 +19,6 @@ Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*/
 
-using System;
 using LtInfo.Common;
 using LtInfo.Common.DhtmlWrappers;
 using LtInfo.Common.Views;
@@ -62,7 +61,7 @@ namespace ProjectFirma.Web.Views.Project
             Add(FieldDefinitionEnum.SecuredFunding.ToType().ToGridHeaderString(), x => x.GetSecuredFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.TargetedFunding.ToType().ToGridHeaderString(), x => x.GetTargetedFunding(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
             Add(FieldDefinitionEnum.NoFundingSourceIdentified.ToType().ToGridHeaderString(), x => x.GetNoFundingSourceIdentifiedAmount(), 100, DhtmlxGridColumnFormatType.Currency, DhtmlxGridColumnAggregationType.Total);
-            Add("Proposed By", a => a.ProposingPerson.GetFullNameFirstLastAndOrgShortNameAsUrl(), 200);
+            Add("Proposed By", a => a.ProposingPerson.GetFullNameFirstLastAndOrgShortNameAsUrl(firmaSession), 200);
             Add("Proposed Date", a => a.ProposingDate, 120);
             Add("Submitted Date", a => a.SubmissionDate, 120);
             Add("Last Updated", a => a.LastUpdatedDate, 120);

--- a/Source/ProjectFirma.Web/Views/ProjectCustomGrid/ProjectCustomGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCustomGrid/ProjectCustomGridSpec.cs
@@ -73,7 +73,8 @@ namespace ProjectFirma.Web.Views.ProjectCustomGrid
             , Dictionary<int,ProjectFirmaModels.Models.TaxonomyLeaf> taxonomyLeafDictionary
             , string projectLabel
             , bool hasProjectApprovalPermissionBySession
-            , string statusUpdateLabel)
+            , string statusUpdateLabel
+            , List<int> sitkaAdminPersonIDs)
         {
 
             switch (projectCustomGridConfiguration.ProjectCustomGridColumn.ToEnum)
@@ -102,7 +103,7 @@ namespace ProjectFirma.Web.Views.ProjectCustomGrid
                 case ProjectCustomGridColumnEnum.ProjectPrimaryContact:
                     Add(FieldDefinitionEnum.ProjectPrimaryContact.ToType().ToGridHeaderString(),
                         x => projectDetailsDictionary[x.ProjectID].PrimaryContactPersonID.HasValue ?
-                            UrlTemplate.MakeHrefString(PersonModelExtensions.DetailUrlTemplate.ParameterReplace(projectDetailsDictionary[x.ProjectID].PrimaryContactPersonID.Value), projectDetailsDictionary[x.ProjectID].PrimaryContactPersonFullNameFirstLast) : new HtmlString(""),
+                            new UserViewFeature().HasPermissionForPersonID(currentFirmaSession, projectDetailsDictionary[x.ProjectID].PrimaryContactPersonID.Value, sitkaAdminPersonIDs).HasPermission ? UrlTemplate.MakeHrefString(PersonModelExtensions.DetailUrlTemplate.ParameterReplace(projectDetailsDictionary[x.ProjectID].PrimaryContactPersonID.Value), projectDetailsDictionary[x.ProjectID].PrimaryContactPersonFullNameFirstLast) : new HtmlString(projectDetailsDictionary[x.ProjectID].PrimaryContactPersonFullNameFirstLast) : new HtmlString(""),
                         150, DhtmlxGridColumnFilterType.Html);
                     break;
                 case ProjectCustomGridColumnEnum.ProjectPrimaryContactEmail:
@@ -261,6 +262,9 @@ namespace ProjectFirma.Web.Views.ProjectCustomGrid
             var hasProjectApprovalPermissionBySession =
                 new ProjectApproveFeature().HasPermissionByFirmaSession(currentFirmaSession);
             var statusUpdateLabel = FieldDefinitionEnum.StatusUpdate.ToType().GetFieldDefinitionLabel();
+            var sitkaAdminPersonIDs =
+                HttpRequestStorage.DatabaseEntities.AllPeople.Where(x =>
+                    x.RoleID == ProjectFirmaModels.Models.Role.SitkaAdmin.RoleID).Select(x => x.PersonID).ToList();
 
             // Mandatory fields before
             AddMandatoryFieldsBefore(userHasTagManagePermissions, userHasReportDownloadPermissions, userHasDeletePermissions, projectCustomGridTypeEnum);
@@ -276,7 +280,8 @@ namespace ProjectFirma.Web.Views.ProjectCustomGrid
                 , projectCustomAttributes
                 , projectLabel
                 , hasProjectApprovalPermissionBySession
-                , statusUpdateLabel);
+                , statusUpdateLabel
+                , sitkaAdminPersonIDs);
 
             // Mandatory fields appearing AFTER configurable fields
             AddMandatoryFieldsAfter(userHasTagManagePermissions);
@@ -293,7 +298,8 @@ namespace ProjectFirma.Web.Views.ProjectCustomGrid
             , Dictionary<int, List<ProjectFirmaModels.Models.vProjectCustomAttributeValue>> projectCustomAttributeDictionary
             , string projectLabel
             , bool hasProjectApprovalPermissionBySession
-            , string statusUpdateLabel)
+            , string statusUpdateLabel
+            , List<int> sitkaAdminPersonIDs)
         {
             
             foreach (var projectCustomGridConfiguration in projectCustomGridConfigurations.OrderBy(x => x.SortOrder))
@@ -317,7 +323,8 @@ namespace ProjectFirma.Web.Views.ProjectCustomGrid
                         , taxonomyLeafDictionary
                         , projectLabel
                         , hasProjectApprovalPermissionBySession
-                        , statusUpdateLabel);
+                        , statusUpdateLabel
+                        , sitkaAdminPersonIDs);
                 }
             }
         }

--- a/Source/ProjectFirma.Web/Views/ProjectStewardOrganization/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectStewardOrganization/IndexGridSpec.cs
@@ -19,14 +19,12 @@ Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*/
 
-using System.Web;
 using LtInfo.Common;
 using LtInfo.Common.DhtmlWrappers;
 using LtInfo.Common.Views;
 using ProjectFirma.Web.Common;
 using ProjectFirma.Web.Models;
 using ProjectFirmaModels.Models;
-using ProjectFirma.Web.Security;
 
 namespace ProjectFirma.Web.Views.ProjectStewardOrganization
 {
@@ -34,11 +32,9 @@ namespace ProjectFirma.Web.Views.ProjectStewardOrganization
     {
         public IndexGridSpec(FirmaSession currentFirmaSession)
         {
-            var userViewFeature = new UserViewFeature();
-            
             Add(FieldDefinitionEnum.Organization.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.OrganizationName), 400, DhtmlxGridColumnFilterType.Html);
             Add("Short Name", a => a.OrganizationShortName, 100);
-            Add(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().ToGridHeaderString(), a => userViewFeature.HasPermission(currentFirmaSession, a.PrimaryContactPerson).HasPermission ? a.GetPrimaryContactPersonAsUrl() : new HtmlString(a.GetPrimaryContactPersonAsString()), 120);
+            Add(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().ToGridHeaderString(), a => a.GetPrimaryContactPersonAsUrl(currentFirmaSession), 120);
             Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", a => a.GetAllActiveProjectsAndProposals(currentFirmaSession.Person).Count, 90);
             Add($"# of {FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized()}", a => a.FundingSources.Count, 150);
             Add("# of Users", a => a.People.Count, 90);

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
@@ -90,7 +90,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
             HasProjectUpdateAdminPermissions = new ProjectUpdateAdminFeature().HasPermissionByFirmaSession(CurrentFirmaSession);
             HasProposeProjectPermissions = new ProjectCreateFeature().HasPermissionByFirmaSession(CurrentFirmaSession);
 
-            GridSpec = new ProjectUpdateStatusGridSpec(projectUpdateStatusFilterType, currentPerson.IsAdministrator() || currentPerson.IsSitkaAdministrator()) {ObjectNameSingular = $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()}",
+            GridSpec = new ProjectUpdateStatusGridSpec(currentFirmaSession, projectUpdateStatusFilterType, currentPerson.IsAdministrator() || currentPerson.IsSitkaAdministrator()) {ObjectNameSingular = $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()}",
                 ObjectNamePlural = $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", SaveFiltersInCookie = true};
             GridDataUrl = gridDataUrl;
             GridName = "myProjectsGrid";

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/PeopleReceivingReminderGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/PeopleReceivingReminderGridSpec.cs
@@ -35,7 +35,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
                 AddCheckBoxColumn();
                 Add("PersonID", x => x.PersonID, 0);
             }
-            Add(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().ToGridHeaderString(), x => x.GetFullNameFirstLastAndOrgShortNameAsUrl(), 220);
+            Add(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().ToGridHeaderString(), x => x.GetFullNameFirstLastAndOrgShortNameAsUrl(currentFirmaSession), 220);
             Add("Email", a => a.Email, 170);
             Add($"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} Requiring Update",
                 x => x.GetPrimaryContactUpdatableProjects(currentFirmaSession).Count,

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ProjectUpdateStatusGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ProjectUpdateStatusGridSpec.cs
@@ -38,7 +38,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
     {
         private readonly bool _canStewardProjects;
 
-        public ProjectUpdateStatusGridSpec(ProjectUpdateStatusFilterTypeEnum projectUpdateStatusFilterTypeEnum,
+        public ProjectUpdateStatusGridSpec(FirmaSession currentFirmaSession, ProjectUpdateStatusFilterTypeEnum projectUpdateStatusFilterTypeEnum,
             bool canStewardProjects)
         {
             _canStewardProjects = canStewardProjects;
@@ -60,7 +60,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
 
             Add(FieldDefinitionEnum.ProjectName.ToType().ToGridHeaderString(), x => UrlTemplate.MakeHrefString(x.GetDetailUrl(), x.ProjectName), 180, DhtmlxGridColumnFilterType.Html);
             Add(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().ToGridHeaderString(),
-                x => x.GetPrimaryContact() == null ? ViewUtilities.NoneString.ToHTMLFormattedString() : x.GetPrimaryContact().GetFullNameFirstLastAndOrgShortNameAsUrl(),
+                x => x.GetPrimaryContact() == null ? ViewUtilities.NoneString.ToHTMLFormattedString() : x.GetPrimaryContact().GetFullNameFirstLastAndOrgShortNameAsUrl(currentFirmaSession),
                 95);
             Add(FieldDefinitionEnum.ProjectStage.ToType().ToGridHeaderString(), x => x.ProjectStage.ProjectStageDisplayName, 80, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(FieldDefinitionEnum.PlanningDesignStartYear.ToType().ToGridHeaderString(), x => ProjectModelExtensions.GetPlanningDesignStartYear(x), 90, DhtmlxGridColumnFilterType.SelectFilterStrict);

--- a/Source/ProjectFirma.Web/Views/Shared/AuditLogsGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Shared/AuditLogsGridSpec.cs
@@ -28,10 +28,10 @@ namespace ProjectFirma.Web.Views.Shared
 {
     public class AuditLogsGridSpec : GridSpec<AuditLog>
     {
-        public AuditLogsGridSpec()
+        public AuditLogsGridSpec(FirmaSession currentFirmaSession)
         {
             Add("Date", a => a.AuditLogDate, 120);
-            Add("User", a => a.Person.GetFullNameFirstLastAndOrgAsUrl(), 300);
+            Add("User", a => a.Person.GetFullNameFirstLastAndOrgAsUrl(currentFirmaSession), 300);
             Add("Section", a => a.TableName.ToProperCase(), 200, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add("Description", a => a.GetAuditDescriptionDisplay(), 400);
         }


### PR DESCRIPTION
moved permission check for UserViewFeature to the PersonModelExtensions to ensure it is always checked when attempting to display a Person's detail url (there were several places the url was displayed but normal users would get an error if they clicked it). Added another method to UserViewFeature which is called in the ProjectCustomGridSpec when we only have a PersonID, and no Person model, but need to check a user's permission to view a detail page of a primary contact.