### PR TITLE
delta-547: Move IsActiveProject from model extensions to model

### DIFF
--- a/Source/ProjectFirma.Api/Models/ProjectDto.cs
+++ b/Source/ProjectFirma.Api/Models/ProjectDto.cs
@@ -54,8 +54,7 @@ namespace ProjectFirma.Api.Models
 
             ProjectCustomAttributes = project.ProjectCustomAttributes.OrderBy(x => x.ProjectCustomAttributeType.ProjectCustomAttributeTypeName).Select(x => new ProjectCustomAttributeDto(x)).ToList();
 
-            // same logic as ProjectFirma.Web.Models.ProjectModelExtensions.IsActiveProject()
-            IsActive = project.ProjectStage != ProjectFirmaModels.Models.ProjectStage.Proposal && project.ProjectApprovalStatus == ProjectApprovalStatus.Approved;
+            IsActive = project.IsActiveProject();
         }
 
         public ProjectDto(Project project, List<int> fundingSourceIDs) : this(project)

--- a/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
@@ -503,7 +503,7 @@ namespace ProjectFirma.Web.Models
 
         public static List<Project> GetActiveProjects(this IList<Project> projects)
         {
-            return projects.Where(x => IsActiveProject(x)).OrderBy(x => x.GetDisplayName()).ToList();
+            return projects.Where(x => x.IsActiveProject()).OrderBy(x => x.GetDisplayName()).ToList();
         }
 
         public static List<Project> GetActiveProposals(this IList<Project> projects, bool showProposals)
@@ -536,36 +536,6 @@ namespace ProjectFirma.Web.Models
         public static List<Project> GetUpdatableProjects(this IQueryable<Project> projects)
         {
             return projects.Where(x => x.IsUpdateMandatory()).ToList();
-        }
-
-        public static bool IsActiveProject(this Project project)
-        {
-            return !project.IsProposal() && project.ProjectApprovalStatus == ProjectApprovalStatus.Approved;
-        }
-
-        public static bool IsProposal(this Project project)
-        {
-            return project.ProjectStage == ProjectStage.Proposal;
-        }
-
-        public static bool IsActiveProposal(this Project project)
-        {
-            return project.IsProposal() && project.ProjectApprovalStatus == ProjectApprovalStatus.PendingApproval;
-        }
-
-        public static bool IsPendingProject(this Project project)
-        {
-            return !project.IsProposal() && project.ProjectApprovalStatus != ProjectApprovalStatus.Approved;
-        }
-
-        public static bool IsPendingApproval(this Project project)
-        {
-            return project.ProjectApprovalStatus == ProjectApprovalStatus.PendingApproval;
-        }
-
-        public static bool IsRejected(this Project project)
-        {
-            return project.ProjectApprovalStatus == ProjectApprovalStatus.Rejected;
         }
 
         public static bool IsForwardLookingFactSheetRelevant(this Project project)

--- a/Source/ProjectFirmaModels/Models/Project.cs
+++ b/Source/ProjectFirmaModels/Models/Project.cs
@@ -220,7 +220,35 @@ namespace ProjectFirmaModels.Models
             }
         }
 
+        public bool IsActiveProject()
+        {
+            return !IsProposal() && ProjectApprovalStatus == ProjectApprovalStatus.Approved;
+        }
 
+        public bool IsProposal()
+        {
+            return ProjectStage == ProjectStage.Proposal;
+        }
+
+        public bool IsActiveProposal()
+        {
+            return IsProposal() && ProjectApprovalStatus == ProjectApprovalStatus.PendingApproval;
+        }
+
+        public bool IsPendingProject()
+        {
+            return !IsProposal() && ProjectApprovalStatus != ProjectApprovalStatus.Approved;
+        }
+
+        public bool IsPendingApproval()
+        {
+            return ProjectApprovalStatus == ProjectApprovalStatus.PendingApproval;
+        }
+
+        public bool IsRejected()
+        {
+            return ProjectApprovalStatus == ProjectApprovalStatus.Rejected;
+        }
 
     }
 }


### PR DESCRIPTION
the ProjectDto needs an IsActive field. Move the IsActiveProject and similar methods into the Project.cs call in ProjectFirmaModels instead of having them in the ProjectModelExtensions.cs class in ProjectFirma.Web so the API can access the method.