### PR TITLE
PF-2234 rework

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/OrganizationController.cs
+++ b/Source/ProjectFirma.Web/Controllers/OrganizationController.cs
@@ -197,7 +197,7 @@ namespace ProjectFirma.Web.Controllers
             var matchmakerOrganizationTaxonomyLeafs = HttpRequestStorage.DatabaseEntities.AllMatchmakerOrganizationTaxonomyLeafs.Local;
         
             viewModel.UpdateModel(organization, matchmakerOrganizationTaxonomyTrunks, matchmakerOrganizationTaxonomyBranches, matchmakerOrganizationTaxonomyLeafs);
-            return new ModalDialogFormJsonResult();
+            return new ModalDialogFormJsonResult(SitkaRoute<OrganizationController>.BuildUrlFromExpression(x => x.Detail(organization, DetailViewData.OrganizationDetailTab.Profile)));
         }
         
         private PartialViewResult ViewEditProfileTaxonomy(EditProfileTaxonomyViewModel viewModel)
@@ -262,9 +262,10 @@ namespace ProjectFirma.Web.Controllers
         }
 
         [OrganizationViewFeature]
-        public ViewResult Detail(OrganizationPrimaryKey organizationPrimaryKey)
+        public ViewResult Detail(OrganizationPrimaryKey organizationPrimaryKey, DetailViewData.OrganizationDetailTab? organizationDetailTab)
         {
             var organization = organizationPrimaryKey.EntityObject;
+            var activeTab = organizationDetailTab ?? DetailViewData.OrganizationDetailTab.Overview;
             var expendituresDirectlyFromOrganizationViewGoogleChartViewData = GetCalendarYearExpendituresFromOrganizationFundingSourcesChartViewData(organization);
             var expendituresReceivedFromOtherOrganizationsViewGoogleChartViewData = GetCalendarYearExpendituresFromProjectFundingSourcesChartViewData(organization, CurrentFirmaSession);
 
@@ -289,7 +290,8 @@ namespace ProjectFirma.Web.Controllers
                                               expendituresDirectlyFromOrganizationViewGoogleChartViewData,
                                               expendituresReceivedFromOtherOrganizationsViewGoogleChartViewData,
                                               topLevelMatchmakerTaxonomyTier,
-                                              maximumTaxonomyLeaves);
+                                              maximumTaxonomyLeaves,
+                                              activeTab);
             return RazorView<Detail, DetailViewData>(viewData);
         }
 

--- a/Source/ProjectFirma.Web/FirmaOwinStartup.cs
+++ b/Source/ProjectFirma.Web/FirmaOwinStartup.cs
@@ -378,7 +378,7 @@ namespace ProjectFirma.Web
     <p>
         You may want to <a href=""{
                     SitkaRoute<OrganizationController>.BuildAbsoluteUrlFromExpression(x => x.Detail(organization
-                        .OrganizationID))
+                        .OrganizationID, null))
                 }"">add detail for this {FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()}</a> such as its abbreviation, {
                     FieldDefinitionEnum.OrganizationType.ToType().GetFieldDefinitionLabel()
                 }, website, logo, etc. This will make its {FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()} summary page display better.

--- a/Source/ProjectFirma.Web/Models/MatchmakerTaxonomyTier.cs
+++ b/Source/ProjectFirma.Web/Models/MatchmakerTaxonomyTier.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Web;
 using LtInfo.Common;
 using LtInfo.Common.Models;
+using ProjectFirma.Web.Common;
 using ProjectFirmaModels.Models;
 
 namespace ProjectFirma.Web.Models
@@ -40,6 +41,21 @@ namespace ProjectFirma.Web.Models
         public string GetDisplayName()
         {
             return DisplayName.ToEllipsifiedString(50);
+        }
+
+        public string GetDisplayNameAsDetailUrl()
+        {
+            switch (TaxonomyLevel)
+            {
+                case TaxonomyLevelEnum.Trunk:
+                    return $"{UrlTemplate.MakeHrefString(TaxonomyTrunk.GetDetailUrl(), GetDisplayName())}";
+                case TaxonomyLevelEnum.Branch:
+                    return $"{UrlTemplate.MakeHrefString(TaxonomyBranch.GetDetailUrl(), GetDisplayName())}";
+                case TaxonomyLevelEnum.Leaf:
+                    return $"{UrlTemplate.MakeHrefString(TaxonomyLeaf.GetDetailUrl(), GetDisplayName())}";
+                default:
+                    return string.Empty;
+            }
         }
 
         public void SetSortOrder(int? value)

--- a/Source/ProjectFirma.Web/Models/OrganizationModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/OrganizationModelExtensions.cs
@@ -68,7 +68,7 @@ namespace ProjectFirma.Web.Models
             return organizationID.HasValue ? UrlTemplate.MakeHrefString(SummaryUrlTemplate.ParameterReplace(organizationID.Value), organizationDisplayName) : new HtmlString(null);
         }
 
-        public static readonly UrlTemplate<int> SummaryUrlTemplate = new UrlTemplate<int>(SitkaRoute<OrganizationController>.BuildUrlFromExpression(t => t.Detail(UrlTemplate.Parameter1Int)));
+        public static readonly UrlTemplate<int> SummaryUrlTemplate = new UrlTemplate<int>(SitkaRoute<OrganizationController>.BuildUrlFromExpression(t => t.Detail(UrlTemplate.Parameter1Int, null)));
         public static string GetDetailUrl(this Organization organization)
         {
             return organization == null ? "" : SummaryUrlTemplate.ParameterReplace(organization.OrganizationID);

--- a/Source/ProjectFirma.Web/PartnerFinder/ProjectOrganizationMatchmaker.cs
+++ b/Source/ProjectFirma.Web/PartnerFinder/ProjectOrganizationMatchmaker.cs
@@ -61,13 +61,10 @@ namespace ProjectFirma.Web.PartnerFinder
             double taxonomySubScore = GetTaxonomySubScore(project, organization);
             CheckEnsureScoreInValidRange(taxonomySubScore);
 
-            // Use FAKE SubScore component.
-            // Artificially gooses scores in the short term, but eventually should be removed as the matching algorithm develops
-            double fakeTermSubScore = 1.0;
-
-            // Hardwired for just two components for the moment, but this will definitely change.
-            double scoreToReturn = taxonomySubScore * 0.5 +
-                                   fakeTermSubScore * 0.5;
+            // Hardwired for just one component for the moment, but this will definitely change.
+            var numberOfComponents = 1;
+            var weightPerSubScore = 1.0 / numberOfComponents; 
+            double scoreToReturn = taxonomySubScore * weightPerSubScore;
 
             // Again, we want to be very sure score values fall between 0.0 and 1.0 inclusive.
             CheckEnsureScoreInValidRange(scoreToReturn);
@@ -77,8 +74,6 @@ namespace ProjectFirma.Web.PartnerFinder
 
         private static double GetTaxonomySubScore(Project project, Organization organization)
         {
-            var taxonomyWeight = 1.0;
-            
             var matchmakerLeaves = organization.MatchmakerOrganizationTaxonomyLeafs.Select(x => x.TaxonomyLeaf).ToList();
             
             var branchIDsIncluded = matchmakerLeaves.Select(x => x.TaxonomyBranchID).ToList();
@@ -99,8 +94,7 @@ namespace ProjectFirma.Web.PartnerFinder
             var matchesLeafForBranch = matchmakerLeavesFromSelectedBranches.Any(x => x.TaxonomyLeafID == project.TaxonomyLeafID);
             var matchesLeafForTrunk = matchmakerLeavesFromSelectedTrunks.Any(x => x.TaxonomyLeafID == project.TaxonomyLeafID);
             
-            double taxonomyScore = matchesLeaf || matchesLeafForBranch || matchesLeafForTrunk ? 1.0 : 0.0;
-            double taxonomySubScore = taxonomyWeight * taxonomyScore;
+            double taxonomySubScore = matchesLeaf || matchesLeafForBranch || matchesLeafForTrunk ? 1.0 : 0.0;
             return taxonomySubScore;
         }
 

--- a/Source/ProjectFirma.Web/Views/Organization/ApproveUploadGisViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/ApproveUploadGisViewData.cs
@@ -18,7 +18,7 @@ namespace ProjectFirma.Web.Views.Organization
         {
             MapInitJson = mapInitJson;
             OrganizationDetailUrl =
-                SitkaRoute<OrganizationController>.BuildUrlFromExpression(c => c.Detail(organization));
+                SitkaRoute<OrganizationController>.BuildUrlFromExpression(c => c.Detail(organization, null));
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
@@ -51,6 +51,10 @@
                 Sitka[gridName1].resizeGridWidths();
                 var gridName2 = @(ViewDataTyped.ProjectFundingSourceExpendituresForOrganizationGridName.ToJS().ToHTMLFormattedString());
                 Sitka[gridName2].resizeGridWidths();
+                var gridName3 = @(ViewDataTyped.ProposalsGridName.ToJS().ToHTMLFormattedString());
+                Sitka[gridName3].resizeGridWidths();
+                var gridName4 = @(ViewDataTyped.PendingProjectsGridName.ToJS().ToHTMLFormattedString());
+                Sitka[gridName4].resizeGridWidths();
                 _.forOwn(window.GoogleCharts.chartWrappers,
                     function (chartWrapper) {
                         if (jQuery('#' + chartWrapper.getContainerId()).is(':visible')) {
@@ -177,12 +181,12 @@
                 <a href="#accomplishments" aria-controls="results" role="tab" data-toggle="tab" id="accomplishmentsTab">Accomplishments</a>
             </li>
             <li>
-                <a href="#details" aria-controls="results" role="tab" data-toggle="tab" id="detailsTab">Details</a>
+                <a href="#details" aria-controls="details" role="tab" data-toggle="tab" id="detailsTab">Details</a>
             </li>
             @if (ViewDataTyped.ShowMatchmakerProfile && ViewDataTyped.UserHasViewEditProfilePermission)
             {
                 <li>
-                    <a href="#profile" aria-controls="results" role="tab" data-toggle="tab" id="profileTab">Profile</a>
+                    <a href="#Profile" aria-controls="Profile" role="tab" data-toggle="tab" id="profileTab">Profile</a>
                 </li>
             }
         </ul>
@@ -641,7 +645,7 @@
 
                 </div>
             </div>
-            <div role="tabpanel" class="tab-pane" id="profile">
+            <div role="tabpanel" class="tab-pane" id="Profile">
                 <div class="row" style="margin-bottom: 20px">
                     <div class="col-xs-12">
                         <h4>@ViewDataTyped.FieldDefinitionForProject.GetFieldDefinitionLabel() Interest (Demand)</h4>
@@ -663,7 +667,7 @@
                                     }
                                     else
                                     {
-                                        <table class="table table-hover table-condensed">
+                                        <table class="table table-condensed">
                                             <thead>
                                             <tr>
                                                 @if (ViewDataTyped.TaxonomyLevel == TaxonomyLevel.Trunk)
@@ -686,17 +690,17 @@
                                                         if (trunk.GrandChildren != null)
                                                         {
                                                             <tr>
-                                                                <td>@trunk.GetDisplayName()</td>
+                                                                <td>@Html.Raw(trunk.GetDisplayNameAsDetailUrl())</td>
                                                                 <td>
                                                                     <div class="taxonomyCount">
-                                                                        <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="right" data-html="true" data-content="@trunk.Children.Select(x => x.GetDisplayName()).ToDelimitedString("<br/>")">
+                                                                        <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="right" data-html="true" data-content="@trunk.Children.Select(x => Html.Raw(x.GetDisplayNameAsDetailUrl())).ToDelimitedString("<br/>")">
                                                                             @trunk.GetTaxonomyTierCountText()
                                                                         </a>
                                                                     </div>
                                                                 </td>
                                                                 <td>
                                                                     <div class="taxonomyCount">
-                                                                        <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="left" data-html="true" data-content="@trunk.GrandChildren.Select(x => x.GetDisplayName()).ToDelimitedString("<br/>")">
+                                                                        <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="left" data-html="true" data-content="@trunk.GrandChildren.Select(x => Html.Raw(x.GetDisplayNameAsDetailUrl())).ToDelimitedString("<br/>")">
                                                                             @MatchmakerTaxonomyTier.GetTaxonomyTierCountText(trunk.GrandChildren.Count, trunk.MaximumGrandChildrenCount, TaxonomyLevelEnum.Leaf)
                                                                         </a>
                                                                     </div>
@@ -708,31 +712,27 @@
                                                             for (int i = 0; i < trunk.Children.Count; i++)
                                                             {
                                                                 var branch = trunk.Children[i];
-                                                                if (branch.Children.Count > 5 || branch.Children.Count == branch.MaximumChildrenCount)
-                                                                {
-                                                                    <tr>
-                                                                        <td style="@(i != 0 ? "border-top:none" : "")">@(i == 0 ? trunk.GetDisplayName() : "")</td>
-                                                                        <td>@(branch.GetDisplayName())</td>
-                                                                        <td>
+                                                                <tr>
+                                                                    <td style="@(i != 0 ? "border-top:none" : "")">@(i == 0 ? Html.Raw(trunk.GetDisplayNameAsDetailUrl()) : new HtmlString(""))</td>
+                                                                    <td>@Html.Raw(branch.GetDisplayNameAsDetailUrl())</td>
+                                                                    <td>
+                                                                        @if (branch.Children.Count > 5 || branch.Children.Count == branch.MaximumChildrenCount)
+                                                                        {
                                                                             <div class="taxonomyCount">
-                                                                                <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="left" data-html="true" data-content="@branch.Children.Select(x => x.GetDisplayName()).ToDelimitedString("<br/>")">
+                                                                                <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="left" data-html="true" data-content="@branch.Children.Select(x => Html.Raw(x.GetDisplayNameAsDetailUrl())).ToDelimitedString("<br/>")">
                                                                                     @branch.GetTaxonomyTierCountText()
                                                                                 </a>
                                                                             </div>
-                                                                        </td>
-                                                                    </tr>
-                                                                }
-                                                                else
-                                                                {
-                                                                    for (int j = 0; j < branch.Children.Count; j++)
-                                                                    {
-                                                                        <tr class="@(j != 0 ? "noBorderRow" : "")">
-                                                                            <td style="@(i != 0 ? "border-top:none" : "")">@(i == 0 && j == 0 ? trunk.GetDisplayName() : "")</td>
-                                                                            <td>@(j == 0 ? branch.GetDisplayName() : "")</td>
-                                                                            <td>@branch.Children[j].GetDisplayName()</td>
-                                                                        </tr>
-                                                                    }
-                                                                }
+                                                                        }
+                                                                        else
+                                                                        {
+                                                                            foreach (var leaf in branch.Children)
+                                                                            {
+                                                                                @Html.Raw(leaf.GetDisplayNameAsDetailUrl())<br />
+                                                                            }
+                                                                        }
+                                                                    </td>
+                                                                </tr>
                                                             }
                                                         }
                                                     }
@@ -741,29 +741,26 @@
                                                 {
                                                     foreach (var branch in ViewDataTyped.TopLevelMatchmakerTaxonomyTier)
                                                     {
-                                                        if (branch.Children.Count > 5 || branch.Children.Count == branch.MaximumChildrenCount)
-                                                        {
-                                                            <tr>
-                                                                <td>@(branch.GetDisplayName())</td>
-                                                                <td>
+                                                        <tr>
+                                                            <td>@Html.Raw(branch.GetDisplayNameAsDetailUrl())</td>
+                                                            <td>
+                                                                @if (branch.Children.Count > 5 || branch.Children.Count == branch.MaximumChildrenCount)
+                                                                {
                                                                     <div class="taxonomyCount">
-                                                                        <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="left" data-html="true" data-content="@branch.Children.Select(x => x.GetDisplayName()).ToDelimitedString("<br/>")">
+                                                                        <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="left" data-html="true" data-content="@branch.Children.Select(x => Html.Raw(x.GetDisplayNameAsDetailUrl())).ToDelimitedString("<br/>")">
                                                                             @branch.GetTaxonomyTierCountText()
                                                                         </a>
                                                                     </div>
-                                                                </td>
-                                                            </tr>
-                                                        }
-                                                        else
-                                                        {
-                                                            for (int j = 0; j < branch.Children.Count; j++)
-                                                            {
-                                                                <tr class="@(j != 0 ? "noBorderRow" : "")">
-                                                                    <td>@(j == 0 ? branch.GetDisplayName() : "")</td>
-                                                                    <td>@branch.Children[j].GetDisplayName()</td>
-                                                                </tr>
-                                                            }
-                                                        }
+                                                                }
+                                                                else
+                                                                {
+                                                                    foreach (var leaf in branch.Children)
+                                                                    {
+                                                                        @Html.Raw(leaf.GetDisplayNameAsDetailUrl())<br />
+                                                                    }
+                                                                }
+                                                            </td>
+                                                        </tr>
                                                     }
                                                 }
                                                 @if (ViewDataTyped.TaxonomyLevel == TaxonomyLevel.Leaf)
@@ -773,7 +770,7 @@
                                                         <tr>
                                                             <td>
                                                                 <div class="taxonomyCount">
-                                                                    <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="right" data-html="true" data-content="@ViewDataTyped.TopLevelMatchmakerTaxonomyTier.Select(x => x.GetDisplayName()).ToDelimitedString("<br/>")">
+                                                                    <a tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-placement="right" data-html="true" data-content="@ViewDataTyped.TopLevelMatchmakerTaxonomyTier.Select(x => Html.Raw(x.GetDisplayNameAsDetailUrl())).ToDelimitedString("<br/>")">
                                                                         @MatchmakerTaxonomyTier.GetTaxonomyTierCountText(ViewDataTyped.TopLevelMatchmakerTaxonomyTier.Count, ViewDataTyped.MaximumTaxonomyLeaves, TaxonomyLevelEnum.Leaf)
                                                                     </a>
                                                                 </div>
@@ -785,11 +782,10 @@
                                                         foreach (var leaf in ViewDataTyped.TopLevelMatchmakerTaxonomyTier)
                                                         {
                                                             <tr>
-                                                                <td>@leaf.GetDisplayName()</td>
+                                                                <td>@Html.Raw(leaf.GetDisplayNameAsDetailUrl())</td>
                                                             </tr>
                                                         }
                                                     }
-                                                    
                                                 }
                                             </tbody>
                                         </table>
@@ -803,3 +799,8 @@
         </div>
     </div>
 </div>
+<script>
+    jQuery(document).ready(function() {
+        $('#organizationDetailsTabs a[href="#@ViewDataTyped.ActiveTab.ToString()"]').tab('show');
+    });
+</script>

--- a/Source/ProjectFirma.Web/Views/Organization/DetailViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/DetailViewData.cs
@@ -33,6 +33,12 @@ namespace ProjectFirma.Web.Views.Organization
 {
     public class DetailViewData : FirmaViewData
     {
+        public enum OrganizationDetailTab
+        {
+            Overview,
+            Profile
+        }
+
         public readonly ProjectFirmaModels.Models.Organization Organization;
         public readonly bool UserHasOrganizationManagePermissions;
         public readonly bool UserHasOrganizationManagePrimaryContactPermissions;
@@ -87,13 +93,13 @@ namespace ProjectFirma.Web.Views.Organization
         public bool UserHasViewEditProfilePermission { get; }
         public ProjectFirmaModels.Models.FieldDefinition FieldDefinitionForProject { get; }
         public string EditProfileTaxonomyUrl { get; }
-
         public List<MatchmakerTaxonomyTier> TopLevelMatchmakerTaxonomyTier { get; }
         public string TaxonomyTrunkDisplayName { get; }
         public string TaxonomyBranchDisplayName { get; }
         public string TaxonomyLeafDisplayName { get; }
         public TaxonomyLevel TaxonomyLevel { get; }
         public int MaximumTaxonomyLeaves { get; }
+        public OrganizationDetailTab ActiveTab { get; }
 
         public DetailViewData(FirmaSession currentFirmaSession,
             ProjectFirmaModels.Models.Organization organization,
@@ -104,7 +110,8 @@ namespace ProjectFirma.Web.Views.Organization
             ViewGoogleChartViewData expendituresDirectlyFromOrganizationViewGoogleChartViewData,
             ViewGoogleChartViewData expendituresReceivedFromOtherOrganizationsViewGoogleChartViewData,
             List<MatchmakerTaxonomyTier> topLevelMatchmakerTaxonomyTier,
-            int maximumTaxonomyLeaves) : base(currentFirmaSession)
+            int maximumTaxonomyLeaves,
+            OrganizationDetailTab activeTab) : base(currentFirmaSession)
         {
             Organization = organization;
             PageTitle = organization.GetDisplayName();
@@ -216,6 +223,7 @@ namespace ProjectFirma.Web.Views.Organization
             TaxonomyLeafDisplayName = FieldDefinitionEnum.TaxonomyLeaf.ToType().GetFieldDefinitionLabel();
             TaxonomyLevel = MultiTenantHelpers.GetTaxonomyLevel();
             MaximumTaxonomyLeaves = maximumTaxonomyLeaves;
+            ActiveTab = activeTab;
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Organization/EditBoundaryViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/EditBoundaryViewData.cs
@@ -23,7 +23,7 @@ namespace ProjectFirma.Web.Views.Organization
             ApproveGisUploadUrl =
                 SitkaRoute<OrganizationController>.BuildUrlFromExpression(c => c.ApproveUploadGis(organization));
             OrganizationDetailUrl =
-                SitkaRoute<OrganizationController>.BuildUrlFromExpression(c => c.Detail(organization));
+                SitkaRoute<OrganizationController>.BuildUrlFromExpression(c => c.Detail(organization, null));
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Results/AccomplishmentsDashboardViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Results/AccomplishmentsDashboardViewData.cs
@@ -64,7 +64,7 @@ namespace ProjectFirma.Web.Views.Results
             ParticipatingOrganizationsUrl = SitkaRoute<ResultsController>.BuildUrlFromExpression(x => x.ParticipatingOrganizations(UrlTemplate.Parameter1Int));
             OrganizationDashboardSummaryUrl = SitkaRoute<ResultsController>.BuildUrlFromExpression(x => x.OrganizationDashboardSummary(UrlTemplate.Parameter1Int));
             OrganizationAccomplishmentsUrl = SitkaRoute<ResultsController>.BuildUrlFromExpression(x => x.OrganizationAccomplishments(UrlTemplate.Parameter1Int, UrlTemplate.Parameter2Int));
-            OrganizationDetailUrl = SitkaRoute<OrganizationController>.BuildUrlFromExpression(x => x.Detail(UrlTemplate.Parameter1Int));
+            OrganizationDetailUrl = SitkaRoute<OrganizationController>.BuildUrlFromExpression(x => x.Detail(UrlTemplate.Parameter1Int, null));
             SpendingByOrganizationTypeAndOrganizationUrl = SitkaRoute<ResultsController>.BuildUrlFromExpression(x => x.SpendingByOrganizationTypeByOrganization(UrlTemplate.Parameter1Int, UrlTemplate.Parameter2Int, UrlTemplate.Parameter3Int));
             AccomplishmentsDashboardOrganizationTypeName = accomplishmentsDashboardOrganizationTypeName;
             TaxonomyTierDisplayName = associatePerformanceMeasureTaxonomyLevel.GetFieldDefinition().GetFieldDefinitionLabel();


### PR DESCRIPTION
reload detail page on the Profile tab when returning from saving the taxonomy selector modal; updated layout of read only display; ensure taxonomy names are hyperlinks; removed fake term of partner finder algorithm.