### PR TITLE
PF-2257: rework: 

### DIFF
--- a/Source/ProjectFirma.Web/Common/FirmaValidationMessages.cs
+++ b/Source/ProjectFirma.Web/Common/FirmaValidationMessages.cs
@@ -41,6 +41,7 @@ namespace ProjectFirma.Web.Common
         public static string ClassificationNameUnique => $"{FieldDefinitionEnum.Classification.ToType().GetFieldDefinitionLabel()} name already exists.";
         public static string PerformanceMeasureNameUnique => $"{FieldDefinitionEnum.PerformanceMeasure.ToType().GetFieldDefinitionLabel()} name already exists.";
         public static string ExplanationNecessaryForProjectExemptYears => $"Please provide an explanation of why the {FieldDefinitionEnum.ReportingYear.ToType().GetFieldDefinitionLabelPluralized()} are exempt.";
+        public static string ExplanationForProjectExemptYearsExceedsMax(int maxCharacters) => $"Explanation of why the {FieldDefinitionEnum.ReportingYear.ToType().GetFieldDefinitionLabelPluralized()} are exempt cannot exceed {maxCharacters} characters.";
         public static string ExplanationNotNecessaryForProjectExemptYears => $"Explanation is not necessary since no {FieldDefinitionEnum.ReportingYear.ToType().GetFieldDefinitionLabelPluralized()} are exempt.";
         public static string TagNameUnique => $"{FieldDefinitionEnum.TagName.ToType().GetFieldDefinitionLabel()} already exists.";
         public static string CompletionYearMustBePastOrPresentForCompletedProjects => $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} in the Completed and Post-Implementation stages cannot have a {FieldDefinitionEnum.CompletionYear.ToType().GetFieldDefinitionLabel()} in the future.";

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/Basics.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/Basics.cshtml
@@ -242,7 +242,7 @@ Source code is available upon request via <support@sitkatech.com>.
                 @Html.LabelWithSugarFor(m => m.PlanningDesignStartYear)
             </div>
             <div class="col-xs-12 col-sm-8">
-                @Html.DropDownListFor(m => m.PlanningDesignStartYear, ViewDataTyped.ValidYearRange, new {@class = "form-control", style = "width: auto;"})
+                @Html.DropDownListFor(m => m.PlanningDesignStartYear, ViewDataTyped.PlanningDesignStartYearRange, new {@class = "form-control", style = "width: auto;"})
                 @Html.ValidationMessageFor(m => m.PlanningDesignStartYear)
             </div>
         </div>
@@ -251,7 +251,7 @@ Source code is available upon request via <support@sitkatech.com>.
                 @Html.LabelWithSugarFor(m => m.ImplementationStartYear)
             </div>
             <div class="col-xs-12 col-sm-8">
-                @Html.DropDownListFor(m => m.ImplementationStartYear, ViewDataTyped.ValidYearRange, new {@class = "form-control", style = "width: auto;"})
+                @Html.DropDownListFor(m => m.ImplementationStartYear, ViewDataTyped.ImplementationStartYearRange, new {@class = "form-control", style = "width: auto;"})
                 @Html.ValidationMessageFor(m => m.ImplementationStartYear)
             </div>
         </div>
@@ -260,7 +260,7 @@ Source code is available upon request via <support@sitkatech.com>.
                 @Html.LabelWithSugarFor(m => m.CompletionYear)
             </div>
             <div class="col-xs-12 col-sm-8">
-                @Html.DropDownListFor(m => m.CompletionYear, ViewDataTyped.ValidYearRange, new {@class = "form-control", style = "width: auto;"})
+                @Html.DropDownListFor(m => m.CompletionYear, ViewDataTyped.CompletionYearRange, new {@class = "form-control", style = "width: auto;"})
                 @Html.ValidationMessageFor(m => m.CompletionYear)
             </div>
         </div>

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/BasicsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/BasicsViewData.cs
@@ -34,7 +34,9 @@ namespace ProjectFirma.Web.Views.ProjectCreate
     {
         public IEnumerable<SelectListItem> TaxonomyLeafs { get; private set; }
         public IEnumerable<SelectListItem> FundingTypes { get; private set; }
-        public IEnumerable<SelectListItem> ValidYearRange { get; private set; }
+        public IEnumerable<SelectListItem> PlanningDesignStartYearRange { get; private set; }
+        public IEnumerable<SelectListItem> ImplementationStartYearRange { get; private set; }
+        public IEnumerable<SelectListItem> CompletionYearRange { get; private set; }
         public int MinValidYear { get; private set; }
         public int MaxValidYear { get; private set; }
         public bool HasCanStewardProjectsOrganizationRelationship { get; private set; }
@@ -83,9 +85,9 @@ namespace ProjectFirma.Web.Views.ProjectCreate
             TaxonomyLeafs = taxonomyLeafs.ToList().OrderTaxonomyLeaves().ToList().ToGroupedSelectList();
             
             FundingTypes = fundingTypes.ToSelectList(x => x.FundingTypeID.ToString(CultureInfo.InvariantCulture), y => y.FundingTypeDisplayName);
-            ValidYearRange =
-                FirmaDateUtilities.YearsForUserInput()
-                    .ToSelectListWithEmptyFirstRow(x => x.CalendarYear.ToString(CultureInfo.InvariantCulture), x => x.CalendarYearDisplay);
+            PlanningDesignStartYearRange = FirmaDateUtilities.YearsForUserInput().ToSelectListWithEmptyFirstRow(x => x.CalendarYear.ToString(CultureInfo.InvariantCulture), x => x.CalendarYearDisplay);
+            ImplementationStartYearRange = FirmaDateUtilities.YearsForUserInput().ToSelectListWithEmptyFirstRow(x => x.CalendarYear.ToString(CultureInfo.InvariantCulture), x => x.CalendarYearDisplay);
+            CompletionYearRange = FirmaDateUtilities.YearsForUserInput().ToSelectListWithEmptyFirstRow(x => x.CalendarYear.ToString(CultureInfo.InvariantCulture), x => x.CalendarYearDisplay);
             MinValidYear = FirmaDateUtilities.YearsForUserInput().Select(x => x.CalendarYear).Min();
             MaxValidYear = FirmaDateUtilities.YearsForUserInput().Select(x => x.CalendarYear).Max();
             HasCanStewardProjectsOrganizationRelationship = MultiTenantHelpers.HasCanStewardProjectsOrganizationRelationship();

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/PerformanceMeasures.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/PerformanceMeasures.cshtml
@@ -67,8 +67,8 @@
         <li>For each @MultiTenantHelpers.GetPerformanceMeasureName(), select the appropriate @FieldDefinitionEnum.PerformanceMeasureSubcategory.ToType().GetFieldDefinitionLabel() options</li>
         <li>Enter the accomplishment value</li>
         <li>
-            You must enter at least one @MultiTenantHelpers.GetPerformanceMeasureName() per year for the duration defined by your project's Start and Completion
-            Years (or, if @FieldDefinitionEnum.CompletionYear.ToType().GetFieldDefinitionLabel() isn't set, through the @Html.LinkWithFieldDefinitionFor(FieldDefinitionEnum.ReportingYear.ToType(), string.Format("current {0}", FieldDefinitionEnum.ReportingYear.ToType().GetFieldDefinitionLabel()), new List<string> { "fieldDefinitionLink" })).
+            You must enter at least one @MultiTenantHelpers.GetPerformanceMeasureName() per year for the duration defined by your @FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()'s Start Year
+            through the @Html.LinkWithFieldDefinitionFor(FieldDefinitionEnum.ReportingYear.ToType(), string.Format("current {0}", FieldDefinitionEnum.ReportingYear.ToType().GetFieldDefinitionLabel()), new List<string> { "fieldDefinitionLink" }).
             If you do not have accomplishments to report for a given year provide a brief explanation.
         </li>
     </ul>

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ReportedPerformanceMeasures.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ReportedPerformanceMeasures.cshtml
@@ -68,8 +68,8 @@
         <li>For each @MultiTenantHelpers.GetPerformanceMeasureName(), select the appropriate @FieldDefinitionEnum.PerformanceMeasureSubcategory.ToType().GetFieldDefinitionLabel() options</li>
         <li>Enter the accomplishment value</li>
         <li>
-            You must enter at least one @MultiTenantHelpers.GetPerformanceMeasureName() per year for the duration defined by your @FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()'s Start and Completion
-            Years (or, if @FieldDefinitionEnum.CompletionYear.ToType().GetFieldDefinitionLabel() isn't set, through the @Html.LinkWithFieldDefinitionFor(FieldDefinitionEnum.ReportingYear.ToType(), string.Format("current {0}", FieldDefinitionEnum.ReportingYear.ToType().GetFieldDefinitionLabel()), new List<string> { "fieldDefinitionLink" })).
+            You must enter at least one @MultiTenantHelpers.GetPerformanceMeasureName() per year for the duration defined by your @FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()'s Start Year 
+            through the @Html.LinkWithFieldDefinitionFor(FieldDefinitionEnum.ReportingYear.ToType(), string.Format("current {0}", FieldDefinitionEnum.ReportingYear.ToType().GetFieldDefinitionLabel()), new List<string> { "fieldDefinitionLink" }).
             If you do not have accomplishments to report for a given year provide a brief explanation.
         </li>
     </ul>

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ReportedPerformanceMeasuresViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ReportedPerformanceMeasuresViewModel.cs
@@ -146,10 +146,18 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (ProjectExemptReportingYearUpdates != null && ProjectExemptReportingYearUpdates.Any(x => x.IsExempt) && string.IsNullOrWhiteSpace(Explanation))
+            if (ProjectExemptReportingYearUpdates != null && ProjectExemptReportingYearUpdates.Any(x => x.IsExempt))
             {
-                yield return new SitkaValidationResult<ReportedPerformanceMeasuresViewModel, string>(
-                    FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears, x => x.Explanation);
+                if (string.IsNullOrWhiteSpace(Explanation))
+                {
+                    yield return new SitkaValidationResult<ReportedPerformanceMeasuresViewModel, string>(
+                        FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears, x => x.Explanation);
+                }
+                else if (Explanation.Length > ProjectUpdateBatch.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation)
+                {
+                    yield return new SitkaValidationResult<ReportedPerformanceMeasuresViewModel, string>(
+                        FirmaValidationMessages.ExplanationForProjectExemptYearsExceedsMax(ProjectUpdateBatch.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation), x => x.Explanation);
+                }
             }
         }
     }


### PR DESCRIPTION
- updated instructions; 
- added validation for length of Explanation for exempt years; 
- updated Project Create validation to require only one actual PM per non-exempt year (not one actual for each PM per year); 
- fixed bug with Project Create where the drop down for Completion Year would have a value auto selected when it should show Choose One