### PR TITLE
PF-2257: rework and bug fixes

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
@@ -477,7 +477,8 @@ namespace ProjectFirma.Web.Controllers
                                       .Any(
                                           x =>
                                               x.ErrorMessage == FirmaValidationMessages.ExplanationNotNecessaryForProjectExemptYears ||
-                                              x.ErrorMessage == FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears);
+                                              x.ErrorMessage == FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears ||
+                                              x.ErrorMessage == FirmaValidationMessages.ExplanationForProjectExemptYearsExceedsMax(Project.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation));
 
             var performanceMeasureSubcategories = performanceMeasures.SelectMany(x => x.PerformanceMeasureSubcategories).Distinct(new HavePrimaryKeyComparer<PerformanceMeasureSubcategory>()).ToList();
             var performanceMeasureSimples = performanceMeasures.Select(x => new PerformanceMeasureSimple(x)).ToList();

--- a/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
@@ -420,7 +420,8 @@ namespace ProjectFirma.Web.Controllers
                                       .Any(
                                           x =>
                                               x.ErrorMessage == FirmaValidationMessages.ExplanationNotNecessaryForProjectExemptYears ||
-                                              x.ErrorMessage == FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears);
+                                              x.ErrorMessage == FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears ||
+                                              x.ErrorMessage == FirmaValidationMessages.ExplanationForProjectExemptYearsExceedsMax(ProjectUpdateBatch.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation));
 
             var performanceMeasureSubcategories = performanceMeasures.SelectMany(x => x.PerformanceMeasureSubcategories).Distinct(new HavePrimaryKeyComparer<PerformanceMeasureSubcategory>()).ToList();
             var performanceMeasureSimples = performanceMeasures.Select(x => new PerformanceMeasureSimple(x)).ToList();

--- a/Source/ProjectFirma.Web/Models/ProjectExemptReportingYearUpdateSimple.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectExemptReportingYearUpdateSimple.cs
@@ -63,6 +63,6 @@ namespace ProjectFirma.Web.Models
         public int ProjectUpdateBatchID { get; set; }
         public int CalendarYear { get; set; }
         public bool IsExempt { get; set; }
-        public string CalendarYearDisplay { get; }
+        public string CalendarYearDisplay { get; set; }
     }
 }

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/PerformanceMeasuresViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/PerformanceMeasuresViewModel.cs
@@ -182,18 +182,15 @@ namespace ProjectFirma.Web.Views.ProjectCreate
         {
             var errors = new List<ValidationResult>();
 
-            if (ProjectExemptReportingYearSimples != null && ProjectExemptReportingYearSimples.Any(x => x.IsExempt))
+            if (ProjectExemptReportingYearSimples != null && ProjectExemptReportingYearSimples.Any(x => x.IsExempt) && string.IsNullOrWhiteSpace(Explanation))
             {
-                if (string.IsNullOrWhiteSpace(Explanation))
-                {
-                    errors.Add(new SitkaValidationResult<PerformanceMeasuresViewModel, string>(FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears, x => x.Explanation));
-                }
-                else if (Explanation.Length > ProjectFirmaModels.Models.Project.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation)
-                {
-                    errors.Add(new SitkaValidationResult<PerformanceMeasuresViewModel, string>(
-                        FirmaValidationMessages.ExplanationForProjectExemptYearsExceedsMax(ProjectFirmaModels.Models.Project.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation),
-                        x => x.Explanation));
-                }
+                errors.Add(new SitkaValidationResult<PerformanceMeasuresViewModel, string>(FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears, x => x.Explanation));
+            }
+            if (!string.IsNullOrWhiteSpace(Explanation) && Explanation.Length > ProjectFirmaModels.Models.Project.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation)
+            {
+                errors.Add(new SitkaValidationResult<PerformanceMeasuresViewModel, string>(
+                    FirmaValidationMessages.ExplanationForProjectExemptYearsExceedsMax(ProjectFirmaModels.Models.Project.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation),
+                    x => x.Explanation));
             }
 
             var pmValidationResults = ValidatePerformanceMeasures();

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ReportedPerformanceMeasures.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ReportedPerformanceMeasures.cshtml
@@ -222,6 +222,7 @@ else
                     </div>
                     <div ng-repeat="projectExemptYearUpdate in AngularModel.ProjectExemptReportingYearUpdates">
                         <input type="hidden" name="@Html.NameFor(x => x.ProjectExemptReportingYearUpdates[0].CalendarYear).ToString().Replace("0", "{{$index}}")" value="{{projectExemptYearUpdate.CalendarYear}}" />
+                        <input type="hidden" name="@Html.NameFor(x => x.ProjectExemptReportingYearUpdates[0].CalendarYearDisplay).ToString().Replace("0", "{{$index}}")" value="{{projectExemptYearUpdate.CalendarYearDisplay}}" />
                         <input type="hidden" name="@Html.NameFor(x => x.ProjectExemptReportingYearUpdates[0].ProjectUpdateBatchID).ToString().Replace("0", "{{$index}}")" value="{{projectExemptYearUpdate.ProjectUpdateBatchID}}" />
                         <input type="hidden" name="@Html.NameFor(x => x.ProjectExemptReportingYearUpdates[0].ProjectExemptReportingYearUpdateID).ToString().Replace("0", "{{$index}}")" value="{{projectExemptYearUpdate.ProjectExemptReportingYearUpdateID}}" />
                         <input type="hidden" name="@Html.NameFor(x => x.ProjectExemptReportingYearUpdates[0].IsExempt).ToString().Replace("0", "{{$index}}")" value="{{projectExemptYearUpdate.IsExempt}}" />

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ReportedPerformanceMeasuresViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ReportedPerformanceMeasuresViewModel.cs
@@ -146,18 +146,15 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (ProjectExemptReportingYearUpdates != null && ProjectExemptReportingYearUpdates.Any(x => x.IsExempt))
+            if (ProjectExemptReportingYearUpdates != null && ProjectExemptReportingYearUpdates.Any(x => x.IsExempt) && string.IsNullOrWhiteSpace(Explanation))
             {
-                if (string.IsNullOrWhiteSpace(Explanation))
-                {
-                    yield return new SitkaValidationResult<ReportedPerformanceMeasuresViewModel, string>(
-                        FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears, x => x.Explanation);
-                }
-                else if (Explanation.Length > ProjectUpdateBatch.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation)
-                {
-                    yield return new SitkaValidationResult<ReportedPerformanceMeasuresViewModel, string>(
-                        FirmaValidationMessages.ExplanationForProjectExemptYearsExceedsMax(ProjectUpdateBatch.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation), x => x.Explanation);
-                }
+                yield return new SitkaValidationResult<ReportedPerformanceMeasuresViewModel, string>(
+                    FirmaValidationMessages.ExplanationNecessaryForProjectExemptYears, x => x.Explanation);
+            }
+            if (!string.IsNullOrWhiteSpace(Explanation) && Explanation.Length > ProjectUpdateBatch.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation)
+            {
+                yield return new SitkaValidationResult<ReportedPerformanceMeasuresViewModel, string>(
+                    FirmaValidationMessages.ExplanationForProjectExemptYearsExceedsMax(ProjectUpdateBatch.FieldLengths.PerformanceMeasureActualYearsExemptionExplanation), x => x.Explanation);
             }
         }
     }


### PR DESCRIPTION
- changed validation to check if Explanation is within allowed length regardless of whether or not years are checked; 
- made sure the except years area is expanded on re-load if the Explanation exceeds max; 
- fixed bug with exempt years of Reported PMs of Project Update where the calendar year would not display next to the checkboxes