### PR TITLE
PF-2250: Control sort order of Taxonomy Branches and Leaves

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/TaxonomyBranchController.cs
+++ b/Source/ProjectFirma.Web/Controllers/TaxonomyBranchController.cs
@@ -232,6 +232,37 @@ namespace ProjectFirma.Web.Controllers
         }
 
         [TaxonomyBranchManageFeature]
+        public PartialViewResult EditSortOrderInGroup()
+        {
+            var taxonomyTrunks = HttpRequestStorage.DatabaseEntities.TaxonomyTrunks.ToList().OrderBy(x => x.GetDisplayName());
+            var viewModel = new EditSortOrderInGroupViewModel();
+            return ViewEditSortOrderInGroup(taxonomyTrunks, viewModel);
+        }
+
+        [HttpPost]
+        [TaxonomyBranchManageFeature]
+        [AutomaticallyCallEntityFrameworkSaveChangesWhenModelValid]
+        public ActionResult EditSortOrderInGroup(EditSortOrderInGroupViewModel viewModel)
+        {
+            var taxonomyTrunks = HttpRequestStorage.DatabaseEntities.TaxonomyTrunks.ToList().OrderBy(x => x.GetDisplayName());
+
+            if (!ModelState.IsValid)
+            {
+                return ViewEditSortOrderInGroup(taxonomyTrunks, viewModel);
+            }
+
+            viewModel.UpdateModel(new List<ISortingGroup>(taxonomyTrunks));
+            SetMessageForDisplay($"Successfully Updated {FieldDefinitionEnum.TaxonomyBranch.ToType().GetFieldDefinitionLabel()} Sort Order");
+            return new ModalDialogFormJsonResult();
+        }
+
+        private PartialViewResult ViewEditSortOrderInGroup(IEnumerable<TaxonomyTrunk> taxonomyTrunks, EditSortOrderInGroupViewModel viewModel)
+        {
+            EditSortOrderInGroupViewData viewData = new EditSortOrderInGroupViewData(new List<ISortingGroup>(taxonomyTrunks), FieldDefinitionEnum.TaxonomyBranch.ToType().GetFieldDefinitionLabelPluralized());
+            return RazorPartialView<EditSortOrderInGroup, EditSortOrderInGroupViewData, EditSortOrderInGroupViewModel>(viewData, viewModel);
+        }
+
+        [TaxonomyBranchManageFeature]
         public PartialViewResult EditChildrenSortOrder(TaxonomyBranchPrimaryKey taxonomyBranchPrimaryKey)
         {
             var taxonomyLeafs = taxonomyBranchPrimaryKey.EntityObject.TaxonomyLeafs;

--- a/Source/ProjectFirma.Web/Controllers/TaxonomyLeafController.cs
+++ b/Source/ProjectFirma.Web/Controllers/TaxonomyLeafController.cs
@@ -322,5 +322,36 @@ namespace ProjectFirma.Web.Controllers
                 $"Successfully Updated {FieldDefinitionEnum.TaxonomyLeaf.ToType().GetFieldDefinitionLabel()} Sort Order");
             return new ModalDialogFormJsonResult();
         }
+
+        [TaxonomyLeafManageFeature]
+        public PartialViewResult EditSortOrderInGroup()
+        {
+            var taxonomyBranches = HttpRequestStorage.DatabaseEntities.TaxonomyBranches.ToList().OrderBy(x => x.GetDisplayName());
+            var viewModel = new EditSortOrderInGroupViewModel();
+            return ViewEditSortOrderInGroup(taxonomyBranches, viewModel);
+        }
+
+        [HttpPost]
+        [TaxonomyLeafManageFeature]
+        [AutomaticallyCallEntityFrameworkSaveChangesWhenModelValid]
+        public ActionResult EditSortOrderInGroup(EditSortOrderInGroupViewModel viewModel)
+        {
+            var taxonomyBranches = HttpRequestStorage.DatabaseEntities.TaxonomyBranches.ToList().OrderBy(x => x.GetDisplayName());
+
+            if (!ModelState.IsValid)
+            {
+                return ViewEditSortOrderInGroup(taxonomyBranches, viewModel);
+            }
+
+            viewModel.UpdateModel(new List<ISortingGroup>(taxonomyBranches));
+            SetMessageForDisplay($"Successfully Updated {FieldDefinitionEnum.TaxonomyLeaf.ToType().GetFieldDefinitionLabel()} Sort Order");
+            return new ModalDialogFormJsonResult();
+        }
+
+        private PartialViewResult ViewEditSortOrderInGroup(IEnumerable<TaxonomyBranch> taxonomyBranches, EditSortOrderInGroupViewModel viewModel)
+        {
+            EditSortOrderInGroupViewData viewData = new EditSortOrderInGroupViewData(new List<ISortingGroup>(taxonomyBranches), FieldDefinitionEnum.TaxonomyLeaf.ToType().GetFieldDefinitionLabelPluralized());
+            return RazorPartialView<EditSortOrderInGroup, EditSortOrderInGroupViewData, EditSortOrderInGroupViewModel>(viewData, viewModel);
+        }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Shared/SortOrder/EditSortOrderInGroup.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/SortOrder/EditSortOrderInGroup.cshtml
@@ -27,13 +27,20 @@
         background-color: #E0E0E0;
     }
 
-    #sortables-list:hover {
+    .sortables-list:hover {
         cursor: move;
         cursor: grab;
     }
 
-    #sortables-list div:hover {
-        background-color: #E0E0E0;
+    .panel-heading a.collapsePanel:after {
+        font-family:'Glyphicons Halflings';
+        content: "\e114";
+        float: left;
+        margin-right: 5px;
+
+    }
+    .panel-heading a.collapsePanel.collapsed:after {
+        content: "\e080";
     }
 </style>
 <span class="systemText">Drag and drop the @ViewDataTyped.SortableNamePlural to set their sorting order.</span>
@@ -42,23 +49,36 @@
 @{
     int itemCount = 0;
 }
-@foreach (var sortingGroup in ViewDataTyped.SortingGroups)
-{
-    <button type="button" class="pull-right btn btn-sm btn-firma" onclick="alphabetize(@itemCount)">Reset @sortingGroup.GetDisplayName() To Alphabetical</button>
-    <h2>@sortingGroup.GetDisplayName()</h2>
-    <div id="sortables-list-@itemCount">
-        @foreach (var sortable in sortingGroup.GetSortableList().SortByOrderThenName().ToArray())
-        {
-            <div data-id="@sortable.GetID()" data-displayName="@sortable.GetDisplayName()" style="font-size: 11pt; margin-bottom: 4px;">
-                <span class="glyphicon glyphicon-menu-hamburger" style="color: #808080; margin-right: 5px;"></span>
-                @sortable.GetDisplayName()
+
+<div class="panel-group" id="accordion">
+    @foreach (var sortingGroup in ViewDataTyped.SortingGroups)
+    {
+        <div class="panel panelFirma">
+            <div class="panel-heading panelTitle">
+                <a data-toggle="collapse" data-target="#panel-@itemCount" href="#panel-@itemCount" class="collapsed collapsePanel">
+                    <span>
+                        @sortingGroup.GetDisplayName()
+                    </span>
+                </a>
             </div>
-        }
+            <div id="panel-@itemCount" class="panel-collapse collapse">
+                <div style="display: inline-block; margin: 4px 15px; float: right">
+                    <button type="button" class=" btn btn-xs btn-firma" onclick="alphabetize(@itemCount)">Reset To Alphabetical</button>
+                </div>
+                <div id="sortables-list-@itemCount" class="sortables-list">
+                    @foreach (var sortable in sortingGroup.GetSortableList().SortByOrderThenName().ToArray())
+                    {
+                        <div data-id="@sortable.GetID()" data-displayName="@sortable.GetDisplayName()" style="font-size: 11pt; margin-bottom: 4px; margin-left: 15px;">
+                            <span class="glyphicon glyphicon-menu-hamburger" style="color: #808080; margin-right: 5px;"></span>
+                            @sortable.GetDisplayName()
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+        itemCount++;
+    }
     </div>
-
-    itemCount++;
-}
-
 @using (Html.BeginForm())
 {
 
@@ -99,5 +119,5 @@
             });
 
         });
-    })
+    });
 </script>

--- a/Source/ProjectFirma.Web/Views/TaxonomyBranch/EditViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyBranch/EditViewModel.cs
@@ -78,6 +78,13 @@ namespace ProjectFirma.Web.Views.TaxonomyBranch
                 ? TaxonomyTrunkID
                 : HttpRequestStorage.DatabaseEntities.TaxonomyTrunks.First().TaxonomyTrunkID; // really should only be one
             taxonomyBranch.ThemeColor = ThemeColor;
+            if (!ModelObjectHelpers.IsRealPrimaryKeyValue(taxonomyBranch.TaxonomyBranchID))
+            {
+                // for new branches, set the sort order to greater than the current max for this trunk (or null if no branches have a sort order set)
+                var maxSortOrder = HttpRequestStorage.DatabaseEntities.TaxonomyBranches
+                    .Where(x => x.TaxonomyTrunkID == taxonomyBranch.TaxonomyTrunkID).Max(x => x.TaxonomyBranchSortOrder);
+                taxonomyBranch.TaxonomyBranchSortOrder = maxSortOrder + 1;
+            }
         }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/Source/ProjectFirma.Web/Views/TaxonomyBranch/Index.cshtml
+++ b/Source/ProjectFirma.Web/Views/TaxonomyBranch/Index.cshtml
@@ -36,6 +36,7 @@
 
     @ModalDialogFormHelper.MakeNewIconButton(ViewDataTyped.NewUrl, string.Format("Create a new {0}", ViewDataTyped.TaxonomyBranchDisplayName), ViewDataTyped.HasTaxonomyBranchManagePermissions && ViewDataTyped.IsNotTaxonomyLevelLeaf)
     @SortOrderHelper.SortOrderModalLink(ViewDataTyped.EditSortOrderUrl, ViewDataTyped.HasTaxonomyBranchManagePermissions && ViewDataTyped.OfferEditSortOrder)
+    @SortOrderHelper.SortOrderModalLink(ViewDataTyped.EditSortOrderInGroupUrl, ViewDataTyped.HasTaxonomyBranchManagePermissions && ViewDataTyped.OfferEditSortOrderInGroup)
 }
 
 <div>

--- a/Source/ProjectFirma.Web/Views/TaxonomyBranch/IndexViewData.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyBranch/IndexViewData.cs
@@ -35,7 +35,9 @@ namespace ProjectFirma.Web.Views.TaxonomyBranch
         public string GridName{ get; }
         public string GridDataUrl{ get; }
         public string EditSortOrderUrl { get; }
+        public string EditSortOrderInGroupUrl { get; }
         public bool OfferEditSortOrder { get; }
+        public bool OfferEditSortOrderInGroup { get; }
         public bool HasTaxonomyBranchManagePermissions { get; }
         public string NewUrl { get; }
         public string TaxonomyBranchDisplayName { get; }
@@ -46,8 +48,10 @@ namespace ProjectFirma.Web.Views.TaxonomyBranch
             var taxonomyBranchDisplayNamePluralized = FieldDefinitionEnum.TaxonomyBranch.ToType().GetFieldDefinitionLabelPluralized();
             PageTitle = taxonomyBranchDisplayNamePluralized;
 
-            // only let them sort tier two taxonomy if that's the highest level.
+            // if branch is the highest level, let them sort without groups
             OfferEditSortOrder = MultiTenantHelpers.IsTaxonomyLevelBranch();
+            // if it is a three tier taxonomy, let them sort grouped by taxonomy trunks
+            OfferEditSortOrderInGroup = MultiTenantHelpers.IsTaxonomyLevelTrunk();
 
             HasTaxonomyBranchManagePermissions = new TaxonomyBranchManageFeature().HasPermissionByFirmaSession(currentFirmaSession);
             IsNotTaxonomyLevelLeaf = !MultiTenantHelpers.IsTaxonomyLevelLeaf();
@@ -64,6 +68,7 @@ namespace ProjectFirma.Web.Views.TaxonomyBranch
             GridDataUrl = SitkaRoute<TaxonomyBranchController>.BuildUrlFromExpression(tc => tc.IndexGridJsonData());
             NewUrl = SitkaRoute<TaxonomyBranchController>.BuildUrlFromExpression(t => t.New());
             EditSortOrderUrl = SitkaRoute<TaxonomyBranchController>.BuildUrlFromExpression(tc => tc.EditSortOrder());
+            EditSortOrderInGroupUrl = SitkaRoute<TaxonomyBranchController>.BuildUrlFromExpression(tc => tc.EditSortOrderInGroup());
             TaxonomyBranchDisplayName = taxonomyBranchDisplayName;
         }
     }

--- a/Source/ProjectFirma.Web/Views/TaxonomyLeaf/EditViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyLeaf/EditViewModel.cs
@@ -75,8 +75,14 @@ namespace ProjectFirma.Web.Views.TaxonomyLeaf
             taxonomyLeaf.TaxonomyBranchID = !MultiTenantHelpers.IsTaxonomyLevelLeaf()
                 ? TaxonomyBranchID
                 : HttpRequestStorage.DatabaseEntities.TaxonomyBranches.First().TaxonomyBranchID; // really should only be one
-            ;
             taxonomyLeaf.ThemeColor = ThemeColor;
+            if (!ModelObjectHelpers.IsRealPrimaryKeyValue(taxonomyLeaf.TaxonomyBranchID))
+            {
+                // for new leaf, set the sort order to greater than the current max for this branch (or null if no leaves have a sort order set)
+                var maxSortOrder = HttpRequestStorage.DatabaseEntities.TaxonomyBranches
+                    .Where(x => x.TaxonomyTrunkID == taxonomyLeaf.TaxonomyBranchID).Max(x => x.TaxonomyBranchSortOrder);
+                taxonomyLeaf.TaxonomyLeafSortOrder = maxSortOrder + 1;
+            }
         }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/Source/ProjectFirma.Web/Views/TaxonomyLeaf/Index.cshtml
+++ b/Source/ProjectFirma.Web/Views/TaxonomyLeaf/Index.cshtml
@@ -22,6 +22,7 @@
 @using ProjectFirma.Web.Views.Shared
 @using LtInfo.Common.DhtmlWrappers
 @using LtInfo.Common.ModalDialog
+@using ProjectFirma.Web.Views.Shared.SortOrder
 @inherits ProjectFirma.Web.Views.TaxonomyLeaf.Index
 @section JavascriptAndStylesContent
 {
@@ -30,6 +31,8 @@
 @section RightOfPageTitle
 {
     @ModalDialogFormHelper.MakeNewIconButton(ViewDataTyped.NewUrl, string.Format("Create a new {0}", ViewDataTyped.TaxonomyLeafDisplayName), ViewDataTyped.HasTaxonomyLeafManagePermissions)
+    @SortOrderHelper.SortOrderModalLink(ViewDataTyped.EditSortOrderUrl, ViewDataTyped.HasTaxonomyLeafManagePermissions && ViewDataTyped.OfferEditSortOrder)
+    @SortOrderHelper.SortOrderModalLink(ViewDataTyped.EditSortOrderInGroupUrl, ViewDataTyped.HasTaxonomyLeafManagePermissions && ViewDataTyped.OfferEditSortOrderInGroup)
 }
 <div>
     @{ ViewPageContent.RenderPartialView(Html, ViewDataTyped.ViewPageContentViewData); }

--- a/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexViewData.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyLeaf/IndexViewData.cs
@@ -32,6 +32,9 @@ namespace ProjectFirma.Web.Views.TaxonomyLeaf
         public string GridName { get; }
         public string GridDataUrl { get; }
         public string EditSortOrderUrl { get; }
+        public string EditSortOrderInGroupUrl { get; }
+        public bool OfferEditSortOrder { get; }
+        public bool OfferEditSortOrderInGroup { get; }
         public bool HasTaxonomyLeafManagePermissions { get; }
         public string NewUrl { get; }
         public string TaxonomyLeafDisplayName { get; }
@@ -40,6 +43,11 @@ namespace ProjectFirma.Web.Views.TaxonomyLeaf
         {
             var taxonomyLeafDisplayNamePluralized = FieldDefinitionEnum.TaxonomyLeaf.ToType().GetFieldDefinitionLabelPluralized();
             PageTitle = taxonomyLeafDisplayNamePluralized;
+
+            // if leaf is the highest level, let them sort without groups
+            OfferEditSortOrder = MultiTenantHelpers.IsTaxonomyLevelLeaf();
+            // if it is a two or three tier taxonomy, let them sort grouped by taxonomy branches
+            OfferEditSortOrderInGroup = !MultiTenantHelpers.IsTaxonomyLevelLeaf();
 
             var hasTaxonomyLeafManagePermissions = new TaxonomyLeafManageFeature().HasPermissionByFirmaSession(currentFirmaSession);
             var taxonomyLeafDisplayName = FieldDefinitionEnum.TaxonomyLeaf.ToType().GetFieldDefinitionLabel();
@@ -53,6 +61,7 @@ namespace ProjectFirma.Web.Views.TaxonomyLeaf
             GridName = "taxonomyLeafsGrid";
             GridDataUrl = SitkaRoute<TaxonomyLeafController>.BuildUrlFromExpression(tc => tc.IndexGridJsonData());
             EditSortOrderUrl = SitkaRoute<TaxonomyLeafController>.BuildUrlFromExpression(tc => tc.EditSortOrder());
+            EditSortOrderInGroupUrl = SitkaRoute<TaxonomyLeafController>.BuildUrlFromExpression(tc => tc.EditSortOrderInGroup());
             HasTaxonomyLeafManagePermissions = hasTaxonomyLeafManagePermissions;
             NewUrl = SitkaRoute<TaxonomyLeafController>.BuildUrlFromExpression(t => t.New());
             TaxonomyLeafDisplayName = taxonomyLeafDisplayName;

--- a/Source/ProjectFirmaModels/Models/TaxonomyBranch.cs
+++ b/Source/ProjectFirmaModels/Models/TaxonomyBranch.cs
@@ -24,7 +24,7 @@ using System.Linq;
 
 namespace ProjectFirmaModels.Models
 {
-    public partial class TaxonomyBranch : IAuditableEntity, IHaveASortOrder
+    public partial class TaxonomyBranch : IAuditableEntity, IHaveASortOrder, ISortingGroup
     {
         public void SetSortOrder(int? value) => TaxonomyBranchSortOrder = value;
 
@@ -44,6 +44,11 @@ namespace ProjectFirmaModels.Models
         public List<IGrouping<PerformanceMeasure, TaxonomyLeafPerformanceMeasure>> GetTaxonomyTierPerformanceMeasures()
         {
             return TaxonomyLeafs.SelectMany(x => x.TaxonomyLeafPerformanceMeasures).GroupBy(y => y.PerformanceMeasure).ToList();
+        }
+
+        public List<IHaveASortOrder> GetSortableList()
+        {
+            return new List<IHaveASortOrder>(TaxonomyLeafs);
         }
     }
 }

--- a/Source/ProjectFirmaModels/Models/TaxonomyTrunk.cs
+++ b/Source/ProjectFirmaModels/Models/TaxonomyTrunk.cs
@@ -24,7 +24,7 @@ using System.Linq;
 
 namespace ProjectFirmaModels.Models
 {
-    public partial class TaxonomyTrunk : IAuditableEntity, IHaveASortOrder
+    public partial class TaxonomyTrunk : IAuditableEntity, IHaveASortOrder, ISortingGroup
     {
         public void SetSortOrder(int? value) => TaxonomyTrunkSortOrder = value;
 
@@ -52,6 +52,11 @@ namespace ProjectFirmaModels.Models
         public List<IGrouping<PerformanceMeasure, TaxonomyLeafPerformanceMeasure>> GetTaxonomyTierPerformanceMeasures()
         {
             return GetTaxonomyLeafs().SelectMany(x => x.TaxonomyLeafPerformanceMeasures).GroupBy(x => x.PerformanceMeasure).ToList();
+        }
+
+        public List<IHaveASortOrder> GetSortableList()
+        {
+            return new List<IHaveASortOrder>(TaxonomyBranches);
         }
     }
 }


### PR DESCRIPTION
- re-do the ui/ux of EditSortOrderInGroup;
- allow users to set the sort order of taxonomy branches and leafs, regardless of the tenant's taxonomy level;