### PR TITLE
PF-2250: rework of UI and change to Reset to Alphabetical ordering

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/ProjectCustomAttributeTypeController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCustomAttributeTypeController.cs
@@ -167,12 +167,12 @@ namespace ProjectFirma.Web.Controllers
         [FirmaAdminFeature]
         public PartialViewResult EditSortOrder()
         {
-            var projectCustomAttributeGroups = HttpRequestStorage.DatabaseEntities.ProjectCustomAttributeGroups;
+            var projectCustomAttributeGroups = HttpRequestStorage.DatabaseEntities.ProjectCustomAttributeGroups.ToList().OrderBy(x => x.GetDisplayName());
             EditSortOrderInGroupViewModel viewModel = new EditSortOrderInGroupViewModel();
             return ViewEditSortOrder(projectCustomAttributeGroups, viewModel);
         }
 
-        private PartialViewResult ViewEditSortOrder(IQueryable<ProjectCustomAttributeGroup> projectCustomAttributeGroups, EditSortOrderInGroupViewModel viewModel)
+        private PartialViewResult ViewEditSortOrder(IEnumerable<ProjectCustomAttributeGroup> projectCustomAttributeGroups, EditSortOrderInGroupViewModel viewModel)
         {
             EditSortOrderInGroupViewData viewData = new EditSortOrderInGroupViewData(new List<ISortingGroup>(projectCustomAttributeGroups), FieldDefinitionEnum.ProjectCustomAttribute.ToType().GetFieldDefinitionLabelPluralized());
             return RazorPartialView<EditSortOrderInGroup, EditSortOrderInGroupViewData, EditSortOrderInGroupViewModel>(viewData, viewModel);
@@ -183,7 +183,7 @@ namespace ProjectFirma.Web.Controllers
         [AutomaticallyCallEntityFrameworkSaveChangesWhenModelValid]
         public ActionResult EditSortOrder(EditSortOrderInGroupViewModel viewModel)
         {
-            var projectCustomAttributeGroups = HttpRequestStorage.DatabaseEntities.ProjectCustomAttributeGroups;
+            var projectCustomAttributeGroups = HttpRequestStorage.DatabaseEntities.ProjectCustomAttributeGroups.ToList().OrderBy(x => x.GetDisplayName());
 
 
             if (!ModelState.IsValid)

--- a/Source/ProjectFirma.Web/Views/Shared/SortOrder/EditSortOrderInGroup.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/SortOrder/EditSortOrderInGroup.cshtml
@@ -32,14 +32,14 @@
         cursor: grab;
     }
 
-    .panel-heading a.collapsePanel:after {
+    .panel-heading a.collapsePanel:before {
         font-family:'Glyphicons Halflings';
         content: "\e114";
         float: left;
         margin-right: 5px;
 
     }
-    .panel-heading a.collapsePanel.collapsed:after {
+    .panel-heading a.collapsePanel.collapsed:before {
         content: "\e080";
     }
 </style>
@@ -55,20 +55,20 @@
     {
         <div class="panel panelFirma">
             <div class="panel-heading panelTitle">
-                <a data-toggle="collapse" data-target="#panel-@itemCount" href="#panel-@itemCount" class="collapsed collapsePanel">
+                <a data-toggle="collapse" data-target="#panel-@itemCount" class="collapsed collapsePanel">
                     <span>
                         @sortingGroup.GetDisplayName()
                     </span>
                 </a>
             </div>
             <div id="panel-@itemCount" class="panel-collapse collapse">
-                <div style="display: inline-block; margin: 4px 15px; float: right">
+                <div style="margin: 4px 15px; text-align: right">
                     <button type="button" class=" btn btn-xs btn-firma" onclick="alphabetize(@itemCount)">Reset To Alphabetical</button>
                 </div>
                 <div id="sortables-list-@itemCount" class="sortables-list">
                     @foreach (var sortable in sortingGroup.GetSortableList().SortByOrderThenName().ToArray())
                     {
-                        <div data-id="@sortable.GetID()" data-displayName="@sortable.GetDisplayName()" style="font-size: 11pt; margin-bottom: 4px; margin-left: 15px;">
+                        <div data-id="@sortable.GetID()" data-displayName="@sortable.GetDisplayName()" style="font-size: 11pt; margin-bottom: 4px; margin-left: 40px; text-indent: -12px;">
                             <span class="glyphicon glyphicon-menu-hamburger" style="color: #808080; margin-right: 5px;"></span>
                             @sortable.GetDisplayName()
                         </div>
@@ -87,13 +87,20 @@
     var allSortableLists = [];
 
     var alphabetize = function (id) {
-        var newWorldOrder = _.sortBy(allSortableLists[id].toArray(),
-            function(sortableId) {
-                var $el = jQuery("[data-id=" + sortableId + "]");
-                var x = $el.attr("data-displayName").toLowerCase();
-                return x;
+
+        var newWorldOrder = allSortableLists[id].toArray().sort(function (sortableIdA, sortableIdB) {
+            var $elA = jQuery("[data-id=" + sortableIdA + "]");
+            var a = $elA.attr("data-displayName").toLowerCase();
+            var $elB = jQuery("[data-id=" + sortableIdB + "]");
+            var b = $elB.attr("data-displayName").toLowerCase();
+            return a.localeCompare(b, undefined, {
+                numeric: true,
+                sensitivity: 'base'
             });
+        });
+
         allSortableLists[id].sort(newWorldOrder);
+
     }
 
     jQuery(function () {


### PR DESCRIPTION
- changed alphabetize function to use localeCompare (numeric = true) so numbers within names are sorted like numbers;
- minor rework of layout for EditSortOrderInGroup;
- sort custom attribute groups by name for the sort editor for custom attribute types;