### PR TITLE
PF-2258 Exception on begin project update for JD

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
@@ -243,8 +243,8 @@ namespace ProjectFirma.Web.Controllers
             if (HttpRequestStorage.DatabaseEntities.PerformanceMeasureReportingPeriods.Any())
             {
                 currentPerformanceMeasureReportingPeriodMaximumYear =
-                    HttpRequestStorage.DatabaseEntities.PerformanceMeasureReportingPeriods.Max(pmrp =>
-                        pmrp.PerformanceMeasureReportingPeriodCalendarYear);
+                    Math.Min(currentCalendarYear, HttpRequestStorage.DatabaseEntities.PerformanceMeasureReportingPeriods.Max(pmrp =>
+                        pmrp.PerformanceMeasureReportingPeriodCalendarYear));
             }
 
             // If these don't already exist when we call GetLatestNotApprovedProjectUpdateBatchOrCreateNew, it can cause problems.


### PR DESCRIPTION
Make sure start calendar year from existing reporting periods
is always less than or equal to the current calendar year.