### PR TITLE
ProjectFirma: Bug with crash on clustering of Projects on Org page

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/OrganizationController.cs
+++ b/Source/ProjectFirma.Web/Controllers/OrganizationController.cs
@@ -308,12 +308,9 @@ namespace ProjectFirma.Web.Controllers
                 return feature;
             }).ToList());
 
-            if (projectSimpleLocationsFeatureCollection.Features.Any())
-            {
-                return new LayerGeoJson($"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", projectSimpleLocationsFeatureCollection, "blue", 1, LayerInitialVisibility.Show);
-            }
-
-            return null;
+            // Always return the feature collection - even if empty.
+            // SLG - 8/28/2020
+            return new LayerGeoJson($"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", projectSimpleLocationsFeatureCollection, "blue", 1, LayerInitialVisibility.Show);
         }
 
         private static MapInitJson GetMapInitJson(Organization organization, out bool hasSpatialData, Person person)


### PR DESCRIPTION
Fixing crash when Organization has no projects. Revealed when bots hit these Organizations. Spoke with Shannon, she agrees no special behavior is needed when there are no Project Locations on the map.