### PR TITLE
PF-2256: made the Profile tab visible if the Matchmaker is enabled for a tenant

### DIFF
--- a/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
@@ -219,7 +219,7 @@
             <li>
                 <a href="#details" aria-controls="details" role="tab" data-toggle="tab" id="detailsTab">Details</a>
             </li>
-            @if (ViewDataTyped.ShowMatchmakerProfile && ViewDataTyped.UserHasViewEditProfilePermission)
+            @if (ViewDataTyped.ShowMatchmakerProfile)
             {
                 <li>
                     <a href="#Profile" aria-controls="Profile" role="tab" data-toggle="tab" id="profileTab">Profile</a>


### PR DESCRIPTION
made the Profile tab visible if the Matchmaker is enabled for a tenant (even if user does not have edit permissions for the Profile)