### PR TITLE
PF-2276: Safe gaurding against null FieldDefinitionDefault

### DIFF
--- a/Database/LookupTables/dbo.FieldDefinition.sql
+++ b/Database/LookupTables/dbo.FieldDefinition.sql
@@ -186,3 +186,5 @@ VALUES
 (362, N'OrganizationInKindServices', N'In-Kind Services'),
 (363, N'OrganizationCommercialServices', N'Commercial Services'),
 (364, N'AreaOfInterest', N'Area of Interest')
+
+-- When appending new field definitions to this insert, you must also create a default definition in dbo.FieldDefinitionDefault. If the definition is unknown, use "not defined" as the default definition.

--- a/Source/ProjectFirma.Web/Controllers/FieldDefinitionController.cs
+++ b/Source/ProjectFirma.Web/Controllers/FieldDefinitionController.cs
@@ -66,7 +66,6 @@ namespace ProjectFirma.Web.Controllers
         public ViewResult Edit(FieldDefinitionPrimaryKey fieldDefinitionPrimaryKey)
         {
             var fieldDefinitionData = HttpRequestStorage.DatabaseEntities.FieldDefinitionDatas.GetFieldDefinitionDataByFieldDefinition(fieldDefinitionPrimaryKey);
-//            var fieldDefinitionDefault = fieldDefinitionData.FieldDefinition.FieldDefinitionDefault;
             var fieldDefinitionDefault = HttpRequestStorage.DatabaseEntities.FieldDefinitionDefaults.GetFieldDefinitionDefaultByFieldDefinition(fieldDefinitionPrimaryKey);            
             var viewModel = new EditViewModel(fieldDefinitionData, fieldDefinitionDefault);
             return ViewEdit(fieldDefinitionPrimaryKey, viewModel);
@@ -90,6 +89,12 @@ namespace ProjectFirma.Web.Controllers
             }
 
             var fieldDefinitionDefault = CurrentFirmaSession.IsSitkaAdministrator() ? HttpRequestStorage.DatabaseEntities.FieldDefinitionDefaults.GetFieldDefinitionDefaultByFieldDefinition(fieldDefinitionPrimaryKey) : null;
+            if (CurrentFirmaSession.IsSitkaAdministrator() && fieldDefinitionDefault == null)
+            {
+                // need to insert a default
+                fieldDefinitionDefault = new FieldDefinitionDefault(fieldDefinitionData.FieldDefinition, "<p><em>not defined</em></p>");
+                HttpRequestStorage.DatabaseEntities.FieldDefinitionDefaults.Add(fieldDefinitionDefault);
+            }
 
             viewModel.UpdateModel(fieldDefinitionData, fieldDefinitionDefault, HttpRequestStorage.DatabaseEntities);
             SetMessageForDisplay("Field Definition successfully saved.");

--- a/Source/ProjectFirma.Web/Views/FieldDefinition/Edit.cshtml
+++ b/Source/ProjectFirma.Web/Views/FieldDefinition/Edit.cshtml
@@ -57,7 +57,7 @@ Source code is available upon request via <support@sitkatech.com>.
                 }
                 else
                 {
-                    @ViewDataTyped.FieldDefinition.FieldDefinitionDefault.DefaultDefinitionHtmlString
+                    @(ViewDataTyped.FieldDefinition.FieldDefinitionDefault != null ? ViewDataTyped.FieldDefinition.FieldDefinitionDefault.DefaultDefinitionHtmlString : new HtmlString(string.Empty))
                     @Html.HiddenFor(m=>m.FieldDefinitionDefault)
                 }
             </div>

--- a/Source/ProjectFirma.Web/Views/FieldDefinition/EditViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/FieldDefinition/EditViewModel.cs
@@ -52,7 +52,7 @@ namespace ProjectFirma.Web.Views.FieldDefinition
         {
             FieldDefinitionDataValue = fieldDefinitionData?.FieldDefinitionDataValueHtmlString;
             FieldDefinitionLabel = fieldDefinitionData?.FieldDefinitionLabel;
-            FieldDefinitionDefault = fieldDefinitionDefault.DefaultDefinitionHtmlString;
+            FieldDefinitionDefault = fieldDefinitionDefault != null && !string.IsNullOrWhiteSpace(fieldDefinitionDefault.DefaultDefinition) ? fieldDefinitionDefault.DefaultDefinitionHtmlString : new HtmlString("<p><em>not defined</em></p>");
         }
 
         public void UpdateModel(FieldDefinitionData fieldDefinitionData, FieldDefinitionDefault fieldDefinitionDefault, DatabaseEntities databaseEntities)


### PR DESCRIPTION
- added comment in sql script to remind developers to add the Default Definition;
- added 'not defined' as a default in the code if it is null when trying to edit the Field Definition; 
- for Admins, made sure the editor would still work if the FieldDefinitionDetault does not exist for a FieldDefinition