### PR TITLE
PF-2285 Bug: Partner page displays in Create Workflow when Matchmaker…

### DIFF
--- a/Source/ProjectFirma.Web/Models/ProjectWorkflowSectionGroupingModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectWorkflowSectionGroupingModelExtensions.cs
@@ -111,7 +111,11 @@ namespace ProjectFirma.Web.Models
 
                 // Partner Finder
                 case ProjectWorkflowSectionGroupingEnum.Partners:
-                    var projectCreateSectionsForPartnerFinder = projectWorkflowSectionGrouping.ProjectCreateSections.ToList();
+                    List<ProjectCreateSection> projectCreateSectionsForPartnerFinder = new List<ProjectCreateSection>();
+                    if (MultiTenantHelpers.GetTenantAttributeFromCache().EnableMatchmaker)
+                    {
+                        projectCreateSectionsForPartnerFinder.AddRange(projectWorkflowSectionGrouping.ProjectCreateSections.ToList());
+                    }
                     return GetProjectCreateSectionsImpl(project, projectCreateSectionsForPartnerFinder, ignoreStatus);
                 default:
                     throw new ArgumentOutOfRangeException($"Unhandled Workflow Section Grouping: {projectWorkflowSectionGrouping.ToEnum}");


### PR DESCRIPTION
… Service is turned off

* disable the partner finder section on the create workflow when the tenant setting is disabled