### PR TITLE
Fix to firma session

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/AssessmentController.cs
+++ b/Source/ProjectFirma.Web/Controllers/AssessmentController.cs
@@ -164,7 +164,7 @@ namespace ProjectFirma.Web.Controllers
         [ProjectsViewFullListFeature]
         public ExcelResult IndexExcelDownload()
         {
-            var projects = HttpRequestStorage.DatabaseEntities.Projects.ToList().GetActiveProjectsAndProposals(CurrentPerson.CanViewProposals());
+            var projects = HttpRequestStorage.DatabaseEntities.Projects.ToList().GetActiveProjectsAndProposals(CurrentFirmaSession.CanViewProposals());
 
             var projectsSpec = new ProjectAssessmentExcelSpec();
             var wsProjects = ExcelWorkbookSheetDescriptorFactory.MakeWorksheet("Projects", projectsSpec, projects);

--- a/Source/ProjectFirma.Web/Controllers/ClassificationController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ClassificationController.cs
@@ -169,7 +169,7 @@ namespace ProjectFirma.Web.Controllers
             var classification = classificationPrimaryKey.EntityObject;
             var mapDivID = $"classification_{classification.ClassificationID}_Map";
             var associatedProjects = classification.GetAssociatedProjects(CurrentFirmaSession);
-            var currentPersonCanViewProposals = CurrentPerson.CanViewProposals();
+            var currentPersonCanViewProposals = CurrentFirmaSession.CanViewProposals();
 
             var projectMapCustomization = ProjectMapCustomization.CreateDefaultCustomization(associatedProjects, currentPersonCanViewProposals);
             var projectLocationsLayerGeoJson = new LayerGeoJson($"{FieldDefinitionEnum.ProjectLocation.ToType().GetFieldDefinitionLabelPluralized()}", associatedProjects.MappedPointsToGeoJsonFeatureCollection(true, false), "red", 1, LayerInitialVisibility.Show);

--- a/Source/ProjectFirma.Web/Controllers/FundingSourceController.cs
+++ b/Source/ProjectFirma.Web/Controllers/FundingSourceController.cs
@@ -191,7 +191,7 @@ namespace ProjectFirma.Web.Controllers
 
         private PartialViewResult ViewDeleteFundingSource(FundingSource fundingSource, ConfirmDialogFormViewModel viewModel)
         {
-            var numberOfProjectsAssociated = fundingSource.GetAssociatedProjects(CurrentPerson).Count;
+            var numberOfProjectsAssociated = fundingSource.GetAssociatedProjects(CurrentFirmaSession).Count;
             var confirmMessage = numberOfProjectsAssociated > 0 ?
                 $"This {FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()} is associated with {numberOfProjectsAssociated} Projects. Deleting the Funding Source will delete all associated expenditure records. Are you sure you wish to delete {FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()} '{fundingSource.FundingSourceName}'?" :
                 $"Are you sure you wish to delete {FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()} '{fundingSource.FundingSourceName}'?";

--- a/Source/ProjectFirma.Web/Controllers/GeospatialAreaController.cs
+++ b/Source/ProjectFirma.Web/Controllers/GeospatialAreaController.cs
@@ -61,7 +61,7 @@ namespace ProjectFirma.Web.Controllers
         {
             var geospatialAreaType = geospatialAreaTypePrimaryKey.EntityObject;
             var gridSpec = new IndexGridSpec(CurrentFirmaSession, geospatialAreaType);
-            var projectIDsViewableByUser = HttpRequestStorage.DatabaseEntities.Projects.ToList().GetActiveProjectsAndProposals(CurrentPerson.CanViewProposals()).Select(x => x.ProjectID).ToList();
+            var projectIDsViewableByUser = HttpRequestStorage.DatabaseEntities.Projects.ToList().GetActiveProjectsAndProposals(CurrentFirmaSession.CanViewProposals()).Select(x => x.ProjectID).ToList();
             var geospatialAreaIndexGridSimples = GeospatialAreaModelExtensions.GetGeospatialAreaIndexGridSimples(geospatialAreaType, projectIDsViewableByUser);
             var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<GeospatialAreaIndexGridSimple>(geospatialAreaIndexGridSimples, gridSpec);
             return gridJsonNetJObjectResult;

--- a/Source/ProjectFirma.Web/Controllers/HomeController.cs
+++ b/Source/ProjectFirma.Web/Controllers/HomeController.cs
@@ -56,7 +56,7 @@ namespace ProjectFirma.Web.Controllers
 
             var firmaHomePageImages = HttpRequestStorage.DatabaseEntities.FirmaHomePageImages.ToList().OrderBy(x => x.SortOrder).ToList();
 
-            var currentPersonCanViewProposals = CurrentPerson.CanViewProposals();
+            var currentPersonCanViewProposals = CurrentFirmaSession.CanViewProposals();
             var projectsToShow = ProjectMapCustomization.ProjectsForMap(currentPersonCanViewProposals);
 
             var projectMapCustomization = ProjectMapCustomization.CreateDefaultCustomization(projectsToShow, currentPersonCanViewProposals);

--- a/Source/ProjectFirma.Web/Controllers/OrganizationController.cs
+++ b/Source/ProjectFirma.Web/Controllers/OrganizationController.cs
@@ -512,11 +512,11 @@ namespace ProjectFirma.Web.Controllers
             var expendituresDirectlyFromOrganizationViewGoogleChartViewData = GetCalendarYearExpendituresFromOrganizationFundingSourcesChartViewData(organization);
             var expendituresReceivedFromOtherOrganizationsViewGoogleChartViewData = GetCalendarYearExpendituresFromProjectFundingSourcesChartViewData(organization, CurrentFirmaSession);
 
-            var mapInitJson = GetMapInitJson(organization, out var hasSpatialData, CurrentPerson);
-            var projectLocationsLayerGeoJson = GetProjectLocationsLayerGeoJson(organization, CurrentPerson);
+            var mapInitJson = GetMapInitJson(organization, out var hasSpatialData, CurrentFirmaSession);
+            var projectLocationsLayerGeoJson = GetProjectLocationsLayerGeoJson(organization, CurrentFirmaSession);
             hasSpatialData = hasSpatialData || projectLocationsLayerGeoJson != null;
 
-            var performanceMeasures = organization.GetAllActiveProjectsAndProposals(CurrentPerson).ToList()
+            var performanceMeasures = organization.GetAllActiveProjectsAndProposals(CurrentFirmaSession).ToList()
                 .SelectMany(x => x.PerformanceMeasureActuals)
                 .Select(x => x.PerformanceMeasure).Distinct(new HavePrimaryKeyComparer<PerformanceMeasure>())
                 .OrderBy(x => x.PerformanceMeasureDisplayName)
@@ -547,9 +547,9 @@ namespace ProjectFirma.Web.Controllers
             return RazorView<Detail, OrganizationDetailViewData>(viewData);
         }
 
-        private static LayerGeoJson GetProjectLocationsLayerGeoJson(Organization organization, Person person)
+        private static LayerGeoJson GetProjectLocationsLayerGeoJson(Organization organization, FirmaSession firmaSession)
         {
-            var allActiveProjectsAndProposals = organization.GetAllActiveProjectsAndProposals(person).Where(x => x.ProjectStage.ShouldShowOnMap()).ToList();
+            var allActiveProjectsAndProposals = organization.GetAllActiveProjectsAndProposals(firmaSession).Where(x => x.ProjectStage.ShouldShowOnMap()).ToList();
 
             var projectsAsSimpleLocations = allActiveProjectsAndProposals.Where(x => x.ProjectLocationSimpleType != ProjectLocationSimpleType.None).ToList();
             var projectSimpleLocationsFeatureCollection = new FeatureCollection();
@@ -565,7 +565,7 @@ namespace ProjectFirma.Web.Controllers
             return new LayerGeoJson($"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", projectSimpleLocationsFeatureCollection, "blue", 1, LayerInitialVisibility.Show);
         }
 
-        private static MapInitJson GetMapInitJson(Organization organization, out bool hasSpatialData, Person person)
+        private static MapInitJson GetMapInitJson(Organization organization, out bool hasSpatialData, FirmaSession firmaSession)
         {
             hasSpatialData = false;
             
@@ -583,7 +583,7 @@ namespace ProjectFirma.Web.Controllers
 
             layers.AddRange(MapInitJson.GetAllGeospatialAreaMapLayers());
 
-            var allActiveProjectsAndProposals = organization.GetAllActiveProjectsAndProposals(person).Where(x => x.ProjectStage.ShouldShowOnMap()).ToList();
+            var allActiveProjectsAndProposals = organization.GetAllActiveProjectsAndProposals(firmaSession).Where(x => x.ProjectStage.ShouldShowOnMap()).ToList();
 
             var projectsAsSimpleLocations = allActiveProjectsAndProposals.Where(x => x.ProjectLocationSimpleType != ProjectLocationSimpleType.None).ToList();
 
@@ -659,7 +659,7 @@ namespace ProjectFirma.Web.Controllers
         {
             var yearRange = FirmaDateUtilities.GetRangeOfYearsForReporting();
 
-            var projects = organization.GetAllActiveProjectsAndProposalsWhereOrganizationIsStewardOrPrimaryContact(currentFirmaSession.Person).ToList();
+            var projects = organization.GetAllActiveProjectsAndProposalsWhereOrganizationIsStewardOrPrimaryContact(currentFirmaSession).ToList();
             var projectFundingSourceExpenditures = projects.SelectMany(x => x.ProjectFundingSourceExpenditures).Where(x => x.FundingSource.Organization != organization);
             
             var chartTitle = $"{FieldDefinitionEnum.ReportedExpenditure.ToType().GetFieldDefinitionLabelPluralized()} By {FieldDefinitionEnum.OrganizationType.ToType().GetFieldDefinitionLabel()}";
@@ -835,7 +835,7 @@ namespace ProjectFirma.Web.Controllers
             var organization = organizationPrimaryKey.EntityObject;
             
             // received
-            var projects = organization.GetAllActiveProjectsAndProposalsWhereOrganizationIsStewardOrPrimaryContact(CurrentPerson).ToList();
+            var projects = organization.GetAllActiveProjectsAndProposalsWhereOrganizationIsStewardOrPrimaryContact(CurrentFirmaSession).ToList();
             var projectFundingSourceExpenditures = projects.SelectMany(x => x.ProjectFundingSourceExpenditures).Where(x => x.FundingSource.Organization != organization).ToList();
 
             // provided

--- a/Source/ProjectFirma.Web/Controllers/ProjectController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectController.cs
@@ -784,7 +784,7 @@ namespace ProjectFirma.Web.Controllers
             var projectIDsFound = HttpRequestStorage.DatabaseEntities.Projects.GetProjectFindResultsForProjectNameAndDescriptionAndNumber(searchCriteria).Select(x => x.ProjectID);
             var projectsFound =
                 HttpRequestStorage.DatabaseEntities.Projects.Where(x => projectIDsFound.Contains(x.ProjectID))
-                    .ToList().GetActiveProjectsAndProposals(CurrentPerson.CanViewProposals());
+                    .ToList().GetActiveProjectsAndProposals(CurrentFirmaSession.CanViewProposals());
             return projectsFound;
         }
 

--- a/Source/ProjectFirma.Web/Controllers/ProjectCustomGridController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCustomGridController.cs
@@ -162,7 +162,7 @@ namespace ProjectFirma.Web.Controllers
             var projectCustomGridConfigurations = HttpRequestStorage.DatabaseEntities.ProjectCustomGridConfigurations.Where(x => x.IsEnabled && x.ProjectCustomGridTypeID == ProjectCustomGridType.Default.ProjectCustomGridTypeID).OrderBy(x => x.SortOrder).ToList();
             var projectDetails = HttpRequestStorage.DatabaseEntities.vProjectDetails.ToDictionary(x => x.ProjectID);
             var gridSpec = new ProjectCustomGridSpec(CurrentFirmaSession, projectCustomGridConfigurations, ProjectCustomGridType.Default.ToEnum, projectDetails, CurrentTenant);
-            var projectTaxonomyTrunks = taxonomyTrunkPrimaryKey.EntityObject.GetAssociatedProjects(CurrentPerson);
+            var projectTaxonomyTrunks = taxonomyTrunkPrimaryKey.EntityObject.GetAssociatedProjects(CurrentFirmaSession);
             var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<Project>(projectTaxonomyTrunks, gridSpec);
             return gridJsonNetJObjectResult;
         }
@@ -174,7 +174,7 @@ namespace ProjectFirma.Web.Controllers
             var projectCustomDefaultGridConfigurations = HttpRequestStorage.DatabaseEntities.ProjectCustomGridConfigurations.Where(x => x.IsEnabled && x.ProjectCustomGridTypeID == ProjectCustomGridType.Default.ProjectCustomGridTypeID).OrderBy(x => x.SortOrder).ToList();
             var projectDetails = HttpRequestStorage.DatabaseEntities.vProjectDetails.ToDictionary(x => x.ProjectID);
             var gridSpec = new ProjectCustomGridSpec(CurrentFirmaSession, projectCustomDefaultGridConfigurations, ProjectCustomGridType.Default.ToEnum, projectDetails, CurrentTenant);
-            var taxonomyBranchProjects = taxonomyBranchPrimaryKey.EntityObject.GetAssociatedProjects(CurrentPerson);
+            var taxonomyBranchProjects = taxonomyBranchPrimaryKey.EntityObject.GetAssociatedProjects(CurrentFirmaSession);
             var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<Project>(taxonomyBranchProjects, gridSpec);
             return gridJsonNetJObjectResult;
         }

--- a/Source/ProjectFirma.Web/Controllers/ResultsController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ResultsController.cs
@@ -152,7 +152,7 @@ namespace ProjectFirma.Web.Controllers
                 MultiTenantHelpers.DisplayAccomplishmentDashboard())
             {
                 var organization = HttpRequestStorage.DatabaseEntities.Organizations.GetOrganization(organizationID);
-                projects = organization.GetAllActiveProjectsAndProposals(CurrentPerson);
+                projects = organization.GetAllActiveProjectsAndProposals(CurrentFirmaSession);
             }
             else
             {
@@ -235,7 +235,7 @@ namespace ProjectFirma.Web.Controllers
             ProjectLocationFilterType projectLocationFilterType;
             ProjectColorByType colorByValue;
 
-            var currentPersonCanViewProposals = CurrentPerson.CanViewProposals();
+            var currentPersonCanViewProposals = CurrentFirmaSession.CanViewProposals();
             if (!String.IsNullOrEmpty(Request.QueryString[ProjectMapCustomization.FilterByQueryStringParameter]))
             {
                 projectLocationFilterType = ProjectLocationFilterType.ToType(Request
@@ -390,7 +390,7 @@ namespace ProjectFirma.Web.Controllers
             var filterFunction =
                 projectLocationFilterTypeFromFilterPropertyName.GetFilterFunction(projectMapCustomization
                     .FilterPropertyValues);
-            var allProjectsForMap = ProjectMapCustomization.ProjectsForMap(CurrentPerson.CanViewProposals());
+            var allProjectsForMap = ProjectMapCustomization.ProjectsForMap(CurrentFirmaSession.CanViewProposals());
             var filteredProjects = allProjectsForMap.Where(filterFunction.Compile())
                 .ToList();
 

--- a/Source/ProjectFirma.Web/Controllers/TagController.cs
+++ b/Source/ProjectFirma.Web/Controllers/TagController.cs
@@ -250,7 +250,7 @@ namespace ProjectFirma.Web.Controllers
         public GridJsonNetJObjectResult<Project> ProjectsGridJsonData(TagPrimaryKey tagPrimaryKey)
         {
             var gridSpec = new BasicProjectInfoGridSpec(CurrentFirmaSession, true);
-            var projectGeospatialAreas = tagPrimaryKey.EntityObject.GetAssociatedProjects(CurrentPerson);
+            var projectGeospatialAreas = tagPrimaryKey.EntityObject.GetAssociatedProjects(CurrentFirmaSession);
             var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<Project>(projectGeospatialAreas, gridSpec);
             return gridJsonNetJObjectResult;
         }

--- a/Source/ProjectFirma.Web/Controllers/TaxonomyBranchController.cs
+++ b/Source/ProjectFirma.Web/Controllers/TaxonomyBranchController.cs
@@ -79,12 +79,12 @@ namespace ProjectFirma.Web.Controllers
         public ViewResult Detail(TaxonomyBranchPrimaryKey taxonomyBranchPrimaryKey)
         {
             var taxonomyBranch = taxonomyBranchPrimaryKey.EntityObject;
-            var taxonomyBranchProjects = taxonomyBranch.GetAssociatedProjects(CurrentFirmaSession.Person).ToList();
+            var taxonomyBranchProjects = taxonomyBranch.GetAssociatedProjects(CurrentFirmaSession).ToList();
 
             var projectMapCustomization = new ProjectMapCustomization(ProjectLocationFilterType.TaxonomyBranch, new List<int> {taxonomyBranch.TaxonomyBranchID}, ProjectColorByType.ProjectStage);
             var projectLocationsLayerGeoJson = new LayerGeoJson($"{FieldDefinitionEnum.ProjectLocation.ToType().GetFieldDefinitionLabel()}", taxonomyBranchProjects.MappedPointsToGeoJsonFeatureCollection(true, true), "red", 1, LayerInitialVisibility.Show);
             var projectLocationsMapInitJson = new ProjectLocationsMapInitJson(projectLocationsLayerGeoJson, projectMapCustomization, "TaxonomyBranchProjectMap", false);
-            var projectLocationsMapViewData = new ProjectLocationsMapViewData(projectLocationsMapInitJson.MapDivID, ProjectColorByType.ProjectStage.GetDisplayNameFieldDefinition(), MultiTenantHelpers.GetTopLevelTaxonomyTiers(), CurrentPerson.CanViewProposals());
+            var projectLocationsMapViewData = new ProjectLocationsMapViewData(projectLocationsMapInitJson.MapDivID, ProjectColorByType.ProjectStage.GetDisplayNameFieldDefinition(), MultiTenantHelpers.GetTopLevelTaxonomyTiers(), CurrentFirmaSession.CanViewProposals());
 
             var associatePerformanceMeasureTaxonomyLevel = MultiTenantHelpers.GetAssociatePerformanceMeasureTaxonomyLevel();
             var canHaveAssociatedPerformanceMeasures = associatePerformanceMeasureTaxonomyLevel == TaxonomyLevel.Branch;

--- a/Source/ProjectFirma.Web/Controllers/TaxonomyLeafController.cs
+++ b/Source/ProjectFirma.Web/Controllers/TaxonomyLeafController.cs
@@ -81,7 +81,7 @@ namespace ProjectFirma.Web.Controllers
         public ViewResult Detail(TaxonomyLeafPrimaryKey taxonomyLeafPrimaryKey)
         {
             var taxonomyLeaf = taxonomyLeafPrimaryKey.EntityObject;
-            var currentPersonCanViewProposals = CurrentPerson.CanViewProposals();
+            var currentPersonCanViewProposals = CurrentFirmaSession.CanViewProposals();
 
             var primaryTaxonomyLeafProjects = taxonomyLeaf.Projects.ToList()
                 .GetActiveProjectsAndProposals(currentPersonCanViewProposals)
@@ -114,10 +114,10 @@ namespace ProjectFirma.Web.Controllers
                 secondaryProjectMapCustomization, "SecondaryTaxonomyLeafProjectMap", false);
             var primaryProjectLocationsMapViewData = new ProjectLocationsMapViewData(primaryProjectLocationsMapInitJson.MapDivID,
                 ProjectColorByType.ProjectStage.GetDisplayNameFieldDefinition(), MultiTenantHelpers.GetTopLevelTaxonomyTiers(),
-                CurrentPerson.CanViewProposals());
+                CurrentFirmaSession.CanViewProposals());
             var secondaryProjectLocationsMapViewData = new ProjectLocationsMapViewData(secondaryProjectLocationsMapInitJson.MapDivID,
                 ProjectColorByType.ProjectStage.GetDisplayNameFieldDefinition(), MultiTenantHelpers.GetTopLevelTaxonomyTiers(),
-                CurrentPerson.CanViewProposals());
+                CurrentFirmaSession.CanViewProposals());
 
             var associatePerformanceMeasureTaxonomyLevel =
                 MultiTenantHelpers.GetAssociatePerformanceMeasureTaxonomyLevel();

--- a/Source/ProjectFirma.Web/Controllers/TaxonomyTrunkController.cs
+++ b/Source/ProjectFirma.Web/Controllers/TaxonomyTrunkController.cs
@@ -76,7 +76,7 @@ namespace ProjectFirma.Web.Controllers
         public ViewResult Detail(TaxonomyTrunkPrimaryKey taxonomyTrunkPrimaryKey)
         {
             var taxonomyTrunk = taxonomyTrunkPrimaryKey.EntityObject;
-            var taxonomyTrunkProjects = taxonomyTrunk.GetAssociatedProjects(CurrentPerson).ToList();
+            var taxonomyTrunkProjects = taxonomyTrunk.GetAssociatedProjects(CurrentFirmaSession).ToList();
 
             var projectMapCustomization = new ProjectMapCustomization(ProjectLocationFilterType.TaxonomyTrunk,
                 new List<int> {taxonomyTrunk.TaxonomyTrunkID}, ProjectColorByType.ProjectStage);
@@ -89,7 +89,7 @@ namespace ProjectFirma.Web.Controllers
 
             var projectLocationsMapViewData = new ProjectLocationsMapViewData(projectLocationsMapInitJson.MapDivID,
                 ProjectColorByType.ProjectStage.GetDisplayNameFieldDefinition(), MultiTenantHelpers.GetTopLevelTaxonomyTiers(),
-                CurrentPerson.CanViewProposals());
+                CurrentFirmaSession.CanViewProposals());
 
             var associatePerformanceMeasureTaxonomyLevel =
                 MultiTenantHelpers.GetAssociatePerformanceMeasureTaxonomyLevel();

--- a/Source/ProjectFirma.Web/Models/ClassificationModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ClassificationModelExtensions.cs
@@ -70,7 +70,7 @@ namespace ProjectFirma.Web.Models
 
         public static List<Project> GetAssociatedProjects(this Classification classification, FirmaSession currentFirmaSession)
         {
-            return classification.ProjectClassifications.Select(ptc => ptc.Project).ToList().GetActiveProjectsAndProposals(currentFirmaSession.Person.CanViewProposals()).ToList();
+            return classification.ProjectClassifications.Select(ptc => ptc.Project).ToList().GetActiveProjectsAndProposals(currentFirmaSession.CanViewProposals()).ToList();
         }
 
         public static string GetKeyImageUrlLarge(this Classification classification) => classification.KeyImageFileResourceInfo != null

--- a/Source/ProjectFirma.Web/Models/FirmaSessionModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/FirmaSessionModelExtensions.cs
@@ -78,5 +78,6 @@ namespace ProjectFirma.Web.Models
         //    return person;
         //}
 
+        public static bool CanViewProposals(this FirmaSession firmaSession) => firmaSession != null && MultiTenantHelpers.ShowProposalsToThePublic() || !firmaSession.IsAnonymousOrUnassigned();
     }
 }

--- a/Source/ProjectFirma.Web/Models/FirmaSessionModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/FirmaSessionModelExtensions.cs
@@ -78,6 +78,6 @@ namespace ProjectFirma.Web.Models
         //    return person;
         //}
 
-        public static bool CanViewProposals(this FirmaSession firmaSession) => firmaSession != null && MultiTenantHelpers.ShowProposalsToThePublic() || !firmaSession.IsAnonymousOrUnassigned();
+        public static bool CanViewProposals(this FirmaSession firmaSession) => firmaSession != null && (MultiTenantHelpers.ShowProposalsToThePublic() || !firmaSession.IsAnonymousOrUnassigned());
     }
 }

--- a/Source/ProjectFirma.Web/Models/FundingSourceModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/FundingSourceModelExtensions.cs
@@ -28,19 +28,19 @@ namespace ProjectFirma.Web.Models
             return SitkaRoute<FundingSourceController>.BuildUrlFromExpression(x => x.Detail(fundingSource.FundingSourceID));
         }
 
-        public static List<Project> GetAssociatedProjects(this FundingSource fundingSource, Person person)
+        public static List<Project> GetAssociatedProjects(this FundingSource fundingSource, FirmaSession firmaSession)
         {
-            return GetAssociatedProjects(fundingSource, person, fundingSource.ProjectFundingSourceExpenditures.ToList());
+            return GetAssociatedProjects(fundingSource, firmaSession, fundingSource.ProjectFundingSourceExpenditures.ToList());
         }
 
-        public static List<Project> GetAssociatedProjects(this FundingSource fundingSource, Person person, List<ProjectFundingSourceExpenditure> projectFundingSourceExpenditures)
+        public static List<Project> GetAssociatedProjects(this FundingSource fundingSource, FirmaSession firmaSession, List<ProjectFundingSourceExpenditure> projectFundingSourceExpenditures)
         {
-            return projectFundingSourceExpenditures.Select(x => x.Project).ToList().GetActiveProjectsAndProposals(person.CanViewProposals());
+            return projectFundingSourceExpenditures.Select(x => x.Project).ToList().GetActiveProjectsAndProposals(firmaSession.CanViewProposals());
         }
 
-        public static List<Project> GetAssociatedProjectsWithSecuredFunding(this FundingSource fundingSource, Person person, List<ProjectFundingSourceBudget> projectFundingSourceBudgets, Dictionary<int,Project> projectDictionary)
+        public static List<Project> GetAssociatedProjectsWithSecuredFunding(this FundingSource fundingSource, FirmaSession firmasession, List<ProjectFundingSourceBudget> projectFundingSourceBudgets, Dictionary<int,Project> projectDictionary)
         {
-            return projectFundingSourceBudgets.Where(x => x.SecuredAmount > 0).Select(x => projectDictionary[x.ProjectID]).ToList().GetActiveProjectsAndProposals(person.CanViewProposals());
+            return projectFundingSourceBudgets.Where(x => x.SecuredAmount > 0).Select(x => projectDictionary[x.ProjectID]).ToList().GetActiveProjectsAndProposals(firmasession.CanViewProposals());
         }
 
         public static string GetDisplayName(this FundingSource fundingSource) =>

--- a/Source/ProjectFirma.Web/Models/GeospatialAreaModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/GeospatialAreaModelExtensions.cs
@@ -128,7 +128,7 @@ namespace ProjectFirma.Web.Models
         public static List<Project> GetAssociatedProjects(this GeospatialArea geospatialArea, FirmaSession currentFirmaSession)
         {
             return geospatialArea.ProjectGeospatialAreas.Select(ptc => ptc.Project).ToList()
-                .GetActiveProjectsAndProposals(currentFirmaSession.Person.CanViewProposals());
+                .GetActiveProjectsAndProposals(currentFirmaSession.CanViewProposals());
         }
 
         public static Feature MakeFeatureWithRelevantProperties(this GeospatialArea geospatialArea)

--- a/Source/ProjectFirma.Web/Models/OrganizationModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/OrganizationModelExtensions.cs
@@ -188,9 +188,9 @@ namespace ProjectFirma.Web.Models
             return projectFundingSourceExpenditures;
         }
 
-        public static  List<Project> GetAllActiveProjectsAndProposals(this Organization organization, Person person)
+        public static  List<Project> GetAllActiveProjectsAndProposals(this Organization organization, FirmaSession firmaSession)
         {
-            return organization.GetAllAssociatedProjects().GetActiveProjectsAndProposals(person.CanViewProposals());
+            return organization.GetAllAssociatedProjects().GetActiveProjectsAndProposals(firmaSession.CanViewProposals());
         }
 
         public static List<Project> GetAllActiveProjects(this Organization organization
@@ -226,9 +226,9 @@ namespace ProjectFirma.Web.Models
             return organization.GetAllAssociatedProjects().GetPendingProjects(person.CanViewPendingProjects());
         }
 
-        public static List<Project> GetAllActiveProjectsAndProposalsWhereOrganizationIsStewardOrPrimaryContact(this Organization organization, Person person)
+        public static List<Project> GetAllActiveProjectsAndProposalsWhereOrganizationIsStewardOrPrimaryContact(this Organization organization, FirmaSession firmaSession)
         {
-            var allActiveProjectsAndProposals = organization.GetAllAssociatedProjects().GetActiveProjectsAndProposals(person.CanViewProposals());
+            var allActiveProjectsAndProposals = organization.GetAllAssociatedProjects().GetActiveProjectsAndProposals(firmaSession.CanViewProposals());
 
             if (MultiTenantHelpers.HasCanStewardProjectsOrganizationRelationship())
             {
@@ -273,7 +273,7 @@ namespace ProjectFirma.Web.Models
                                                                                          PerformanceMeasure performanceMeasure, 
                                                                                          FirmaSession firmaSession)
         {
-            var projects = organization.GetAllActiveProjectsAndProposals(firmaSession.Person).ToList();
+            var projects = organization.GetAllActiveProjectsAndProposals(firmaSession).ToList();
             return new PerformanceMeasureChartViewData(performanceMeasure, firmaSession, false, projects);
         }
 

--- a/Source/ProjectFirma.Web/Models/PerformanceMeasureModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/PerformanceMeasureModelExtensions.cs
@@ -230,7 +230,7 @@ namespace ProjectFirma.Web.Models
 
         public static List<Project> GetAssociatedProjectsWithReportedValues(this PerformanceMeasure performanceMeasure, FirmaSession currentFirmaSession)
         {
-            return performanceMeasure.PerformanceMeasureActuals.Select(ptc => ptc.Project).ToList().GetActiveProjectsAndProposals(currentFirmaSession.Person.CanViewProposals());
+            return performanceMeasure.PerformanceMeasureActuals.Select(ptc => ptc.Project).ToList().GetActiveProjectsAndProposals(currentFirmaSession.CanViewProposals());
         }
 
         public static int ReportedProjectsCount(this PerformanceMeasure performanceMeasure, FirmaSession currentFirmaSession)

--- a/Source/ProjectFirma.Web/Models/PersonModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/PersonModelExtensions.cs
@@ -137,7 +137,7 @@ namespace ProjectFirma.Web.Models
             {
                 return person.ProjectsWhereYouAreThePrimaryContactPerson.ToList().Where(x => x.ProjectStage != ProjectStage.Terminated).ToList();
             }
-            return person.ProjectsWhereYouAreThePrimaryContactPerson.ToList().GetActiveProjectsAndProposals(currentFirmaSession.Person.CanViewProposals()).ToList();
+            return person.ProjectsWhereYouAreThePrimaryContactPerson.ToList().GetActiveProjectsAndProposals(currentFirmaSession.CanViewProposals()).ToList();
         }
 
         /// <summary>
@@ -176,7 +176,6 @@ namespace ProjectFirma.Web.Models
             return Role.ProjectSteward.RoleID == person.RoleID;
         }
 
-        public static bool CanViewProposals(this Person person) => person != null && MultiTenantHelpers.ShowProposalsToThePublic() || !person.IsUnassigned();
 
         public static List<HtmlString> GetProjectStewardshipAreaHtmlStringList(this Person person)
         {

--- a/Source/ProjectFirma.Web/Models/TagModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/TagModelExtensions.cs
@@ -34,9 +34,9 @@ namespace ProjectFirma.Web.Models
             return tag == null;
         }
 
-        public static List<Project> GetAssociatedProjects(this Tag tag, Person currentPerson)
+        public static List<Project> GetAssociatedProjects(this Tag tag, FirmaSession currentFirmaSession)
         {
-            return tag.ProjectTags.Select(x => x.Project).ToList().GetActiveProjectsAndProposals(currentPerson.CanViewProposals());
+            return tag.ProjectTags.Select(x => x.Project).ToList().GetActiveProjectsAndProposals(currentFirmaSession.CanViewProposals());
         }
     }
 }

--- a/Source/ProjectFirma.Web/Models/TaxonomyBranchModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/TaxonomyBranchModelExtensions.cs
@@ -36,9 +36,9 @@ namespace ProjectFirma.Web.Models
             return taxonomyBranch == null;
         }
 
-        public static List<Project> GetAssociatedProjects(this TaxonomyBranch taxonomyBranch, Person person)
+        public static List<Project> GetAssociatedProjects(this TaxonomyBranch taxonomyBranch, FirmaSession firmaSession)
         {
-            return taxonomyBranch.TaxonomyLeafs.SelectMany(y => y.Projects).ToList().GetActiveProjectsAndProposals(person.CanViewProposals());
+            return taxonomyBranch.TaxonomyLeafs.SelectMany(y => y.Projects).ToList().GetActiveProjectsAndProposals(firmaSession.CanViewProposals());
         }
 
 

--- a/Source/ProjectFirma.Web/Models/TaxonomyLeafModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/TaxonomyLeafModelExtensions.cs
@@ -56,7 +56,7 @@ namespace ProjectFirma.Web.Models
 
         public static List<Project> GetAssociatedProjects(this TaxonomyLeaf taxonomyLeaf, FirmaSession currentFirmaSession)
         {
-            return taxonomyLeaf.Projects.ToList().GetActiveProjectsAndProposals(currentFirmaSession.Person.CanViewProposals());
+            return taxonomyLeaf.Projects.ToList().GetActiveProjectsAndProposals(currentFirmaSession.CanViewProposals());
         }
 
         public static List<Project> GetAssociatedPrimaryAndSecondaryProjects(this TaxonomyLeaf taxonomyLeaf, FirmaSession currentFirmaSession)
@@ -65,7 +65,7 @@ namespace ProjectFirma.Web.Models
                 .Union(taxonomyLeaf.SecondaryProjectTaxonomyLeafs.Select(x => x.Project))
                 .Distinct(new HavePrimaryKeyComparer<Project>())
                 .ToList()
-                .GetActiveProjectsAndProposals(currentFirmaSession.Person.CanViewProposals());
+                .GetActiveProjectsAndProposals(currentFirmaSession.CanViewProposals());
         }
 
         public static IEnumerable<SelectListItem> ToGroupedSelectList(this List<TaxonomyLeaf> taxonomyLeafs)

--- a/Source/ProjectFirma.Web/Models/TaxonomyTrunkModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/TaxonomyTrunkModelExtensions.cs
@@ -41,9 +41,9 @@ namespace ProjectFirma.Web.Models
             return ProjectMapCustomization.BuildCustomizedUrl(ProjectLocationFilterType.TaxonomyTrunk, taxonomyTrunk.TaxonomyTrunkID.ToString(), ProjectColorByType.ProjectStage);
         }
 
-        public static List<Project> GetAssociatedProjects(this TaxonomyTrunk taxonomyTrunk, Person currentPerson)
+        public static List<Project> GetAssociatedProjects(this TaxonomyTrunk taxonomyTrunk, FirmaSession firmaSession)
         {
-            return taxonomyTrunk.TaxonomyBranches.SelectMany(x => x.TaxonomyLeafs.SelectMany(y => y.Projects)).ToList().GetActiveProjectsAndProposals(currentPerson.CanViewProposals());
+            return taxonomyTrunk.TaxonomyBranches.SelectMany(x => x.TaxonomyLeafs.SelectMany(y => y.Projects)).ToList().GetActiveProjectsAndProposals(firmaSession.CanViewProposals());
         }
 
         public static FancyTreeNode ToFancyTreeNode(this TaxonomyTrunk taxonomyTrunk, FirmaSession currentFirmaSession)

--- a/Source/ProjectFirma.Web/Views/FundingSource/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/FundingSource/IndexGridSpec.cs
@@ -35,7 +35,7 @@ namespace ProjectFirma.Web.Views.FundingSource
     {
         public IndexGridSpec(FirmaSession currentFirmaSession, List<ProjectFirmaModels.Models.FundingSourceCustomAttributeType> fundingSourceCustomAttributeTypes)
         {
-            var currentPerson = currentFirmaSession.Person;
+            
             var projectFundingSourceBudgets = HttpRequestStorage.DatabaseEntities.ProjectFundingSourceBudgets
                 .GroupBy(x => x.FundingSourceID)
                 .ToDictionary(x => x.Key, y => y.ToList());
@@ -63,10 +63,10 @@ namespace ProjectFirma.Web.Views.FundingSource
             
             Add(FieldDefinitionEnum.FundingSourceAmount.ToType().ToGridHeaderString(), a => a.FundingSourceAmount, 80, DhtmlxGridColumnFormatType.Currency);
             
-            Add($"{FieldDefinitionEnum.NumberOfProjectsWithExpendedFunds.ToType().ToGridHeaderString()}", a => a.GetAssociatedProjects(currentPerson, a.GetProjectFundingSourceExpendituresFromDictionary(projectFundingSourceExpenditureDictionary)).Count, 90);
+            Add($"{FieldDefinitionEnum.NumberOfProjectsWithExpendedFunds.ToType().ToGridHeaderString()}", a => a.GetAssociatedProjects(currentFirmaSession, a.GetProjectFundingSourceExpendituresFromDictionary(projectFundingSourceExpenditureDictionary)).Count, 90);
             Add($"{FieldDefinitionEnum.TotalExpenditures.ToType().ToGridHeaderString()}", a => a.GetProjectFundingSourceExpendituresFromDictionary(projectFundingSourceExpenditureDictionary).Sum(x => x.ExpenditureAmount), 100, DhtmlxGridColumnFormatType.Currency);
             Add($"{FieldDefinitionEnum.NumberOfProjectsWithSecuredFunds.ToType().ToGridHeaderString()}"
-                , a => a.GetAssociatedProjectsWithSecuredFunding(currentPerson, a.GetProjectFundingSourceBudgetsFromDictionary(projectFundingSourceBudgets), projectDictionary).Count
+                , a => a.GetAssociatedProjectsWithSecuredFunding(currentFirmaSession, a.GetProjectFundingSourceBudgetsFromDictionary(projectFundingSourceBudgets), projectDictionary).Count
                 , 90);
             Add($"{FieldDefinitionEnum.TotalProjectSecuredFunds.ToType().ToGridHeaderString()}", a => a.GetProjectFundingSourceBudgetsFromDictionary(projectFundingSourceBudgets).Sum(x => x.SecuredAmount), 80, DhtmlxGridColumnFormatType.Currency);
             Add($"{FieldDefinitionEnum.TotalProjectTargetedFunds.ToType().ToGridHeaderString()}", a => a.GetProjectFundingSourceBudgetsFromDictionary(projectFundingSourceBudgets).Sum(x => x.TargetedAmount), 80, DhtmlxGridColumnFormatType.Currency);

--- a/Source/ProjectFirma.Web/Views/Organization/OrganizationDetailViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/OrganizationDetailViewData.cs
@@ -208,7 +208,7 @@ namespace ProjectFirma.Web.Views.Organization
             CanCreateNewFundingSource = new FundingSourceCreateFeature().HasPermissionByFirmaSession(currentFirmaSession) &&
                                         (currentFirmaSession.Person.RoleID != ProjectFirmaModels.Models.Role.ProjectSteward.RoleID || // If person is project steward, they can only create funding sources for their organization
                                          currentFirmaSession.Person.OrganizationID == organization.OrganizationID);
-            ShowProposals = currentFirmaSession.Person.CanViewProposals();
+            ShowProposals = currentFirmaSession.CanViewProposals();
             ProposalsPanelHeader = MultiTenantHelpers.ShowProposalsToThePublic()
                 ? FieldDefinitionEnum.Proposal.ToType().GetFieldDefinitionLabelPluralized()
                 : $"{FieldDefinitionEnum.Proposal.ToType().GetFieldDefinitionLabelPluralized()} (Not Visible to the Public)";

--- a/Source/ProjectFirma.Web/Views/Organization/OrganizationIndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/OrganizationIndexGridSpec.cs
@@ -56,7 +56,7 @@ namespace ProjectFirma.Web.Views.Organization
             Add(FieldDefinitionEnum.OrganizationType.ToType().ToGridHeaderString(), x => x.OrganizationType?.GetOrganizationTypeHtmlStringWithColor(), 100, DhtmlxGridColumnFilterType.SelectFilterHtmlStrict);
             Add(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().ToGridHeaderString(), a => a.GetPrimaryContactPersonAsUrl(currentFirmaSession), 120);
             Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} associated with this {FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()}", a => a.GetAllActiveProjects(fundingSourceDictionary, projectFundingSourceBudgetsDictionary, projectFundingSourceExpenditureDictionary, projectDictionary).Count, 90);
-            if (currentFirmaSession.Person.CanViewProposals())
+            if (currentFirmaSession.CanViewProposals())
             {
                 Add($"# of {FieldDefinitionEnum.Proposal.ToType().GetFieldDefinitionLabelPluralized()} associated with this {FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()}"
                     , a => a.GetProposalsVisibleToUser(currentFirmaSession, fundingSourceDictionary, projectFundingSourceBudgetsDictionary, projectFundingSourceExpenditureDictionary, projectDictionary).Count, 90);

--- a/Source/ProjectFirma.Web/Views/ProjectStewardOrganization/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectStewardOrganization/IndexGridSpec.cs
@@ -35,7 +35,7 @@ namespace ProjectFirma.Web.Views.ProjectStewardOrganization
             Add(FieldDefinitionEnum.Organization.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.OrganizationName), 400, DhtmlxGridColumnFilterType.Html);
             Add("Short Name", a => a.OrganizationShortName, 100);
             Add(FieldDefinitionEnum.OrganizationPrimaryContact.ToType().ToGridHeaderString(), a => a.GetPrimaryContactPersonAsUrl(currentFirmaSession), 120);
-            Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", a => a.GetAllActiveProjectsAndProposals(currentFirmaSession.Person).Count, 90);
+            Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", a => a.GetAllActiveProjectsAndProposals(currentFirmaSession).Count, 90);
             Add($"# of {FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized()}", a => a.FundingSources.Count, 150);
             Add("# of Users", a => a.People.Count, 90);
             

--- a/Source/ProjectFirma.Web/Views/TaxonomyBranch/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyBranch/IndexGridSpec.cs
@@ -46,7 +46,7 @@ namespace ProjectFirma.Web.Views.TaxonomyBranch
             }            
             Add(FieldDefinitionEnum.TaxonomyBranch.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.GetTaxonomyBranchCodeAndName()), 240);
             Add(FieldDefinitionEnum.TaxonomyLeaf.ToType().ToGridHeaderString(), a => new HtmlString(string.Join("<br/>", a.TaxonomyLeafs.SortByOrderThenName().Select(x => x.GetDisplayNameAsUrl()))), 420, DhtmlxGridColumnFilterType.Html);
-            Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", a => a.GetAssociatedProjects(currentFirmaSession.Person).Count, 90);
+            Add($"# of {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()}", a => a.GetAssociatedProjects(currentFirmaSession).Count, 90);
             Add("Sort Order", a => a.TaxonomyBranchSortOrder, 90, DhtmlxGridColumnFormatType.None);
             Add(FieldDefinitionEnum.TaxonomyBranchDescription.ToType().ToGridHeaderString(),a => a.TaxonomyBranchDescription, 200, DhtmlxGridColumnFilterType.SelectFilterHtmlStrict);
         }

--- a/Source/ProjectFirma.Web/Views/TaxonomyTrunk/IndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/TaxonomyTrunk/IndexGridSpec.cs
@@ -42,7 +42,7 @@ namespace ProjectFirma.Web.Views.TaxonomyTrunk
 
             Add(FieldDefinitionEnum.TaxonomyTrunk.ToType().ToGridHeaderString(), a => UrlTemplate.MakeHrefString(a.GetDetailUrl(), a.TaxonomyTrunkName), 240);
             Add(FieldDefinitionEnum.TaxonomyBranch.ToType().ToGridHeaderString(), a => new HtmlString(string.Join("<br/>", a.TaxonomyBranches.SortByOrderThenName().Select(x => x.GetDisplayNameAsUrl()))), 340, DhtmlxGridColumnFilterType.Html);
-            Add("# of Projects", a => a.GetAssociatedProjects(firmaSession.Person).Count, 90);
+            Add("# of Projects", a => a.GetAssociatedProjects(firmaSession).Count, 90);
             Add("Sort Order", a => a.TaxonomyTrunkSortOrder, 90, DhtmlxGridColumnFormatType.None);
             Add(FieldDefinitionEnum.TaxonomyTrunkDescription.ToType().ToGridHeaderString(),
                 a => a.TaxonomyTrunkDescription, 200,


### PR DESCRIPTION
Hey Stewart!

As part of resolving acceptance tests for PF-2302, I noticed a potential bug related to the "Show proposals to public" tenant configuration option. Doing some debugging I found that when running the `PersonModelExtension.CanViewProposals()` extension method, it would return false if the Person was null. 

There were a lot of places in the code that were calling `currentFirmaSession.Person.CanViewProposals()`, which when run for an anonymous user, the `Person` would be null and return false regardless of whether or not the "Show proposals to public" tenant config option is enabled.

__I think__ what is committed here is an appropriate fix, but I definitely want to run it by you for any feedback or any gotcha's that I might have missed!