### PR TITLE
PF-2149: rework

### DIFF
--- a/Database/ReleaseScript/0470 - Rename ReportingYearStartDate to FiscalYearStartDate on Tenant table and update FieldDefinitionDefault.sql
+++ b/Database/ReleaseScript/0470 - Rename ReportingYearStartDate to FiscalYearStartDate on Tenant table and update FieldDefinitionDefault.sql
@@ -8,3 +8,8 @@ update dbo.ProjectUpdateSetting set ProjectUpdateKickOffDate = (select FiscalYea
 update dbo.ProjectUpdateSetting set ProjectUpdateCloseOutDate = '1990-12-31' where TenantID != 3 and ProjectUpdateCloseOutDate is null
 update dbo.ProjectUpdateSetting set ProjectUpdateCloseOutDate = '2020-06-30' where TenantID = 3
 
+
+-- kick-off date
+update dbo.FieldDefinitionDefault set DefaultDefinition = 'The date (month and day) that the currently configured reporting period starts. If enabled, Kick-off email reminders will be sent on this date.' where FieldDefinitionID = 261
+-- close-out date
+update dbo.FieldDefinitionDefault set DefaultDefinition = 'The date (month and day) that the currently configured reporting period ends. If enabled, Close-out emails will be sent relative to this date.' where FieldDefinitionID = 263

--- a/Source/ProjectFirma.Web/Common/FirmaDateUtilities.cs
+++ b/Source/ProjectFirma.Web/Common/FirmaDateUtilities.cs
@@ -63,20 +63,39 @@ namespace ProjectFirma.Web.Common
 
         public static DateTime LastReportingPeriodStartDate()
         {
-            var startDayOfReportingYear = MultiTenantHelpers.GetStartDayOfReportingYear();
-            return new DateTime(CalculateCurrentYearToUseForRequiredReporting(), startDayOfReportingYear.Month, startDayOfReportingYear.Day);
+            var startDayOfReportingPeriod = MultiTenantHelpers.GetStartDayOfReportingPeriod();
+            return new DateTime(CalculateCurrentYearToUseForRequiredReporting(), startDayOfReportingPeriod.Month, startDayOfReportingPeriod.Day);
+        }
+
+        public static DateTime LastReportingPeriodEndDate()
+        {
+            var startDayOfReportingYear = MultiTenantHelpers.GetStartDayOfReportingPeriod();
+            var startDate = new DateTime(CalculateCurrentYearToUseForRequiredReporting(), startDayOfReportingYear.Month, startDayOfReportingYear.Day);
+            var endDateOfReportingPeriod = MultiTenantHelpers.GetEndDayOfReportingPeriod();
+            if (startDayOfReportingYear.Month < endDateOfReportingPeriod.Month ||
+                startDayOfReportingYear.Month == endDateOfReportingPeriod.Month &&
+                startDayOfReportingYear.Day < endDateOfReportingPeriod.Day)
+            {
+                // end day of reporting is in the same calendar year as start day
+                return new DateTime(startDate.Year, endDateOfReportingPeriod.Month, endDateOfReportingPeriod.Day);
+            }
+            else
+            {
+                // end day is in the next calendar year
+                return new DateTime(startDate.Year + 1, endDateOfReportingPeriod.Month, endDateOfReportingPeriod.Day);
+            }
         }
 
         public static int CalculateCurrentYearToUseForRequiredReporting()
         {
-            var startDayOfReportingYear = MultiTenantHelpers.GetStartDayOfReportingYear();
-            return CalculateCurrentYearToUseForReportingImpl(DateTime.Today, startDayOfReportingYear.Month, startDayOfReportingYear.Day);
+            var startDayOfReportingPeriod = MultiTenantHelpers.GetStartDayOfReportingPeriod();
+            return CalculateCurrentYearToUseForReportingImpl(DateTime.Today, startDayOfReportingPeriod.Month, startDayOfReportingPeriod.Day);
         }
 
         //Only public for unit testing
         public static int CalculateCurrentYearToUseForReportingImpl(DateTime currentDateTime, int reportingStartMonth, int reportingStartDay)
         {
-            var dateToCheckAgainst = new DateTime(currentDateTime.Year, reportingStartMonth, reportingStartDay);
+            var dateToCheckAgainst = new DateTime(currentDateTime.Year, reportingStartMonth, reportingStartDay);//
             return currentDateTime.IsDateBefore(dateToCheckAgainst) ? currentDateTime.Year - 1 : currentDateTime.Year;
         }
 
@@ -97,7 +116,7 @@ namespace ProjectFirma.Web.Common
 
         public static int CalculateCurrentYearToUseForUpToAllowableInputInReporting()
         {
-            var startDayOfReportingYear = MultiTenantHelpers.GetStartDayOfReportingYear();
+            var startDayOfReportingYear = MultiTenantHelpers.GetStartDayOfReportingPeriod();
             var currentDateTime = DateTime.Today;
             var dateToCheckAgainst = new DateTime(currentDateTime.Year, startDayOfReportingYear.Month, startDayOfReportingYear.Day);
             if (MultiTenantHelpers.UseFiscalYears())

--- a/Source/ProjectFirma.Web/Common/MultiTenantHelpers.cs
+++ b/Source/ProjectFirma.Web/Common/MultiTenantHelpers.cs
@@ -293,13 +293,13 @@ namespace ProjectFirma.Web.Common
             return projectUpdateConfiguration;
         }
 
-        public static DateTime GetStartDayOfReportingYear()
+        public static DateTime GetStartDayOfReportingPeriod()
         {
             var projectUpdateConfiguration = GetProjectUpdateConfiguration();
             return projectUpdateConfiguration.ProjectUpdateKickOffDate ?? HttpRequestStorage.Tenant.FiscalYearStartDate;
         }
 
-        public static DateTime GetEndDayOfReportingYear()
+        public static DateTime GetEndDayOfReportingPeriod()
         {
             var projectUpdateConfiguration = GetProjectUpdateConfiguration();
             return projectUpdateConfiguration.ProjectUpdateCloseOutDate.GetValueOrDefault();

--- a/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
@@ -230,7 +230,7 @@ namespace ProjectFirma.Web.Controllers
             }
 
             viewModel.UpdateModel(MultiTenantHelpers.GetProjectUpdateConfiguration());
-            SetMessageForDisplay("Notifications configured successfully.");
+            SetMessageForDisplay("Reporting period configuration and reminders successfully saved.");
 
             return new ModalDialogFormJsonResult();
         }

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
@@ -54,13 +54,13 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
         public MyProjectsViewData(FirmaSession currentFirmaSession, ProjectFirmaModels.Models.FirmaPage firmaPage, ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum projectUpdateStatusFilterType, string gridDataUrl) : base(currentFirmaSession, firmaPage)
         {
             ProjectUpdateStatusFilterType = projectUpdateStatusFilterType;
-            var startDayOfReportingYearAsString = MultiTenantHelpers.GetStartDayOfReportingYear().ToStringDateMonthDay();
-            var endDayOfReportingYearAsString = MultiTenantHelpers.GetEndDayOfReportingYear().ToStringDateMonthDay();
+            var startDayOfReportingYearAsString = MultiTenantHelpers.GetStartDayOfReportingPeriod().ToStringDateMonthDay();
+            var endDayOfReportingYearAsString = MultiTenantHelpers.GetEndDayOfReportingPeriod().ToStringDateMonthDay();
             switch (projectUpdateStatusFilterType)
             {
                 case ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.MyProjectsRequiringAnUpdate:
                     PageTitle =
-                        $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} Requiring an Update: Reporting Period: {startDayOfReportingYearAsString} - {endDayOfReportingYearAsString}";
+                        $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} Updates for Reporting Period: {startDayOfReportingYearAsString} - {endDayOfReportingYearAsString}";
                     break;
                 case ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.MySubmittedProjects:
                     PageTitle =

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ProjectUpdateStatusGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ProjectUpdateStatusGridSpec.cs
@@ -49,8 +49,9 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
                 x =>
                 {
                     var projectUpdateState = x.GetLatestUpdateStateResilientToDuplicateUpdateBatches();
+                    var latestApprovedUpdateBatch = x.GetLatestApprovedUpdateBatch();
                     if (projectUpdateState == null ||
-                        (projectUpdateState == ProjectUpdateState.Approved && x.GetLatestApprovedUpdateBatch().LastUpdateDate < FirmaDateUtilities.LastReportingPeriodStartDate()))
+                        (projectUpdateState == ProjectUpdateState.Approved && latestApprovedUpdateBatch != null && !(FirmaDateUtilities.LastReportingPeriodStartDate() < latestApprovedUpdateBatch.LastUpdateDate && latestApprovedUpdateBatch.LastUpdateDate < FirmaDateUtilities.LastReportingPeriodEndDate())))
                         return "Not Started";
 
                     return projectUpdateState.ToEnum.ToString();
@@ -179,21 +180,6 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
                 x =>
                 {
                     var latestUpdateState = x.GetLatestUpdateStateResilientToDuplicateUpdateBatches();
-
-                    if (!x.IsUpdateMandatory() && (latestUpdateState == null || latestUpdateState == ProjectUpdateState.Approved))
-                    {
-                        return
-                            ModalDialogFormHelper.ModalDialogFormLink("Begin",
-                                SitkaRoute<ProjectController>.BuildUrlFromExpression(y => y.ConfirmNonMandatoryUpdate(x.PrimaryKey)),
-                                $"Update this {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()}?",
-                                400,
-                                "Continue",
-                                "Cancel",
-                                new List<string> { "btn", "btn-xs", "btn-firma" },
-                                null,
-                                null);
-                    }
-
                     var linkText = "Begin";
                     if (latestUpdateState == ProjectUpdateState.Created)
                     {


### PR DESCRIPTION
- update default definitions of Kick-off and Close-out dates
- update growl message when saving changes to project update configuration
- updated logic for ProjectUpdateStatusGridSpec so the "Reporting Period Update Status" column will say "Not Started" if there is an approved update but that approval did not occur in the current reporting period window.