### PR TITLE
PF-2149: Project Update Configuration rework/bug fixes

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
@@ -189,7 +189,7 @@ namespace ProjectFirma.Web.Controllers
                     projects = projects.Where(p => p.IsMyProject(CurrentFirmaSession) && p.IsUpdateMandatory() && p.GetLatestUpdateState() != ProjectUpdateState.Submitted);
                     break;
                 case ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.MySubmittedProjects:
-                    projects = projects.Where(p => p.IsMyProject(CurrentFirmaSession) && (!p.IsUpdateMandatory() || p.GetLatestUpdateState() == ProjectUpdateState.Submitted));
+                    projects = projects.Where(p => p.IsMyProject(CurrentFirmaSession) && p.GetLatestUpdateState() == ProjectUpdateState.Submitted && p.IsUpdateForReportingPeriod());
                     break;
                 case ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.SubmittedProjects:
                     projects = projects.Where(p =>
@@ -3976,7 +3976,8 @@ namespace ProjectFirma.Web.Controllers
             var emailContentPreview = new ProjectUpdateNotificationHelper(
                 tenantAttribute.PrimaryContactPerson.Email, introContent, "",
                 tenantAttribute.TenantSquareLogoFileResourceInfo ?? tenantAttribute.TenantBannerLogoFileResourceInfo,
-                MultiTenantHelpers.GetToolDisplayName()).GetEmailContentPreview();
+                MultiTenantHelpers.GetToolDisplayName(),
+                tenantAttribute.TenantID).GetEmailContentPreview();
 
             return emailContentPreview;
         }

--- a/Source/ProjectFirma.Web/Models/FieldDefinitionModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/FieldDefinitionModelExtensions.cs
@@ -36,6 +36,11 @@ namespace ProjectFirma.Web.Models
         public static string GetFieldDefinitionLabel(this FieldDefinition fieldDefinition)
         {
             var fieldDefinitionData = fieldDefinition.GetFieldDefinitionData();
+            return fieldDefinition.GetFieldDefinitionLabelImpl(fieldDefinitionData);
+        }
+
+        private static string GetFieldDefinitionLabelImpl(this FieldDefinition fieldDefinition, IFieldDefinitionData fieldDefinitionData)
+        {
             if (fieldDefinitionData != null && !String.IsNullOrWhiteSpace(fieldDefinitionData.FieldDefinitionLabel))
             {
                 return fieldDefinitionData.FieldDefinitionLabel;
@@ -68,6 +73,22 @@ namespace ProjectFirma.Web.Models
         public static string GetContentUrl(this FieldDefinition fieldDefinition)
         {
             return SitkaRoute<FieldDefinitionController>.BuildUrlFromExpression(x => x.FieldDefinitionDetails(fieldDefinition.FieldDefinitionID));
+        }
+
+        public static IFieldDefinitionData GetFieldDefinitionDataForBackgroundJob(this FieldDefinition fieldDefinition, int tenantID)
+        {
+            return fieldDefinition.FieldDefinitionDatas.SingleOrDefault(x => x.TenantID == tenantID);
+        }
+
+        public static string GetFieldDefinitionLabelForBackgroundJob(this FieldDefinition fieldDefinition, int tenantID)
+        {
+            var fieldDefinitionData = fieldDefinition.GetFieldDefinitionDataForBackgroundJob(tenantID);
+            return fieldDefinition.GetFieldDefinitionLabelImpl(fieldDefinitionData);
+        }
+
+        public static string GetFieldDefinitionLabelPluralizedForBackgroundJob(this FieldDefinition fieldDefinition, int tenantID)
+        {
+            return PluralizationService.Pluralize(fieldDefinition.GetFieldDefinitionLabelForBackgroundJob(tenantID));
         }
     }
 }

--- a/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
@@ -804,7 +804,23 @@ namespace ProjectFirma.Web.Models
                 return true;
             }
 
-            if (!latestUpdateBatch.IsApproved())
+            if (!latestUpdateBatch.IsApproved() || !(FirmaDateUtilities.LastReportingPeriodStartDate() < latestUpdateBatch.LastUpdateDate && latestUpdateBatch.LastUpdateDate < FirmaDateUtilities.LastReportingPeriodEndDate()))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsUpdateForReportingPeriod(this Project project)
+        {
+            var latestUpdateBatch = project.GetLatestUpdateBatch();
+            if (latestUpdateBatch == null)
+            {
+                return false;
+            }
+
+            if (FirmaDateUtilities.LastReportingPeriodStartDate() < latestUpdateBatch.LastUpdateDate && latestUpdateBatch.LastUpdateDate < FirmaDateUtilities.LastReportingPeriodEndDate())
             {
                 return true;
             }

--- a/Source/ProjectFirma.Web/ScheduledJobs/ProjectUpdateNotificationHelper.cs
+++ b/Source/ProjectFirma.Web/ScheduledJobs/ProjectUpdateNotificationHelper.cs
@@ -17,6 +17,7 @@ namespace ProjectFirma.Web.ScheduledJobs
         public FileResourceInfo ToolLogo { get; set; }
         public string ReminderEmailSubject { get; set; }
         public string ContactSupportEmail { get; set; }
+        public int TenantID { get; set; }
 
         private const string ReminderMessageTemplate = @"Hello {0},<br/><br/>
 {1}
@@ -27,13 +28,14 @@ namespace ProjectFirma.Web.ScheduledJobs
 
 
         public ProjectUpdateNotificationHelper(string contactSupportEmail, string introContent, string reminderSubject,
-            FileResourceInfo toolLogo, string toolDisplayName)
+            FileResourceInfo toolLogo, string toolDisplayName, int tenantID)
         {
             ContactSupportEmail = contactSupportEmail;
             IntroContent = introContent;
             ReminderEmailSubject = reminderSubject;
             ToolLogo = toolLogo;
             ToolName = toolDisplayName;
+            TenantID = tenantID;
         }
 
         public List<Notification> SendProjectUpdateReminderMessage(
@@ -84,7 +86,7 @@ namespace ProjectFirma.Web.ScheduledJobs
                 fullNameFirstLast,
                 IntroContent,
                 projectsRequiringAnUpdateUrl,
-                FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized().ToLower(),
+                FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralizedForBackgroundJob(TenantID).ToLower(),
                 projectListConcatenated);
             var emailContent = $"{body}<br/>{signature}";
             return emailContent;
@@ -104,8 +106,8 @@ namespace ProjectFirma.Web.ScheduledJobs
 
             return GetEmailContent(
                 SitkaRoute<ProjectUpdateController>.BuildUrlFromExpression(x => x.MyProjectsRequiringAnUpdate()),
-                $"<em>Organization {FieldDefinitionEnum.OrganizationPrimaryContact.ToType().GetFieldDefinitionLabel()}</em>",
-                $"<p><em>A list of the recipient’s {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized().ToLower()} that require an update and do not have an update submitted yet will appear here.&nbsp;</em></p>",
+                $"<em>Organization {FieldDefinitionEnum.OrganizationPrimaryContact.ToType().GetFieldDefinitionLabelForBackgroundJob(TenantID)}</em>",
+                $"<p><em>A list of the recipient’s {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralizedForBackgroundJob(TenantID).ToLower()} that require an update and do not have an update submitted yet will appear here.&nbsp;</em></p>",
                 signature
             );
         }
@@ -133,7 +135,7 @@ namespace ProjectFirma.Web.ScheduledJobs
 Thank you,<br />
 {ToolName} team<br/><br/><img src=""{logoUrl}"" width=""160"" />
 <p>
-P.S. - You received this email because you are listed as the {FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabel()} for these {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized().ToLower()}. If you feel that you should not be the {FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabel()} for one or more of these {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized().ToLower()}, please <a href=""mailto:{ContactSupportEmail}"">contact support</a>.
+P.S. - You received this email because you are listed as the {FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabelForBackgroundJob(TenantID)} for these {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralizedForBackgroundJob(TenantID).ToLower()}. If you feel that you should not be the {FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabelForBackgroundJob(TenantID)} for one or more of these {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized().ToLower()}, please <a href=""mailto:{ContactSupportEmail}"">contact support</a>.
 </p>";
         }
     }

--- a/Source/ProjectFirma.Web/ScheduledJobs/ProjectUpdateReminderScheduledBackgroundJob.cs
+++ b/Source/ProjectFirma.Web/ScheduledJobs/ProjectUpdateReminderScheduledBackgroundJob.cs
@@ -2,6 +2,7 @@
 using ProjectFirmaModels.Models;
 using System;
 using System.Collections.Generic;
+using System.Data.Entity.Infrastructure.Pluralization;
 using System.Linq;
 using LtInfo.Common;
 using ProjectFirma.Web.Models;
@@ -100,12 +101,11 @@ namespace ProjectFirma.Web.ScheduledJobs
         {
             // Constrain to tenant boundaries.
             var toolDisplayName = attribute.ToolDisplayName;
-
             var contactSupportEmail = attribute.PrimaryContactPerson.Email;
-
             var toolLogo = attribute.TenantSquareLogoFileResourceInfo;
-
-            var projectUpdateNotificationHelper = new ProjectUpdateNotificationHelper(contactSupportEmail, introContent, reminderSubject, toolLogo, toolDisplayName);
+            var tenantID = attribute.TenantID;
+            
+            var projectUpdateNotificationHelper = new ProjectUpdateNotificationHelper(contactSupportEmail, introContent, reminderSubject, toolLogo, toolDisplayName, tenantID);
 
             var projectsToNotifyOn = notifyOnAll
                 ? projectsForTenant.AsQueryable().GetUpdatableProjects()
@@ -114,7 +114,12 @@ namespace ProjectFirma.Web.ScheduledJobs
             var projectsGroupedByPrimaryContact =
                 projectsToNotifyOn.Where(x => x.GetPrimaryContact() != null).GroupBy(x => x.GetPrimaryContact())
                     .ToList();
-
+            foreach (var test in projectsGroupedByPrimaryContact)
+            {
+                
+                Logger.Info($"PrimaryContact: {test.Key.LastName}; projects {string.Join(", ",test.ToList().Select(x => x.ProjectName))}");
+            }
+            
             var notifications = projectsGroupedByPrimaryContact
                 .SelectMany(x => projectUpdateNotificationHelper.SendProjectUpdateReminderMessage(x)).ToList();
 

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/EditProjectUpdateConfiguration.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/EditProjectUpdateConfiguration.cshtml
@@ -53,6 +53,8 @@
 @using (Html.BeginForm())
 {
     <div class="form-horizontal">
+        <p>Use this form to configure a reporting period for project updates and set up reminders to be sent to all project primary contacts with projects requiring an update. Project updates can be made throughout the year regardless of whether there is an active reporting period.</p>
+        <p>A reporting period is required and can be any length of time within a year. You can change the reporting period throughout the year to support multiple reporting periods in one year. However if you change the period during an active reporting period, the reporting status of each project will be updated, which could be confusing to users.</p>
         @Html.ValidationSummary()
         <div class="form-group">
             <div class="col-xs-4 control-label">@Html.LabelWithSugarFor(m => m.ProjectUpdateKickOffDate)</div>
@@ -107,7 +109,7 @@
         <div class="form-group">
             <div class="col-xs-4 control-label">@Html.LabelWithSugarFor(m => m.ProjectUpdateReminderInterval)</div>
             <div class="col-xs-8">
-                @Html.TextBoxFor(m => m.ProjectUpdateReminderInterval, new { @class = "form-control", style = "width:185px;" })
+                @Html.TextBoxFor(m => m.ProjectUpdateReminderInterval, new {@class = "form-control", style = "width:185px;"})
             </div>
         </div>
         <div class="form-group">
@@ -134,7 +136,7 @@
         <div class="form-group">
             <div class="col-xs-4 control-label">@Html.LabelWithSugarFor(m => m.DaysBeforeCloseOutDateForReminder)</div>
             <div class="col-xs-8">
-                @Html.TextBoxFor(m => m.DaysBeforeCloseOutDateForReminder, new { @class = "form-control", style = "width:185px;" })
+                @Html.TextBoxFor(m => m.DaysBeforeCloseOutDateForReminder, new {@class = "form-control", style = "width:185px;"})
             </div>
         </div>
         <div class="form-group">

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
@@ -60,11 +60,11 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
             {
                 case ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.MyProjectsRequiringAnUpdate:
                     PageTitle =
-                        $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} Updates for Reporting Period: {startDayOfReportingYearAsString} - {endDayOfReportingYearAsString}";
+                        $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} Requiring an Update for Reporting Period: {startDayOfReportingYearAsString} - {endDayOfReportingYearAsString}";
                     break;
                 case ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.MySubmittedProjects:
                     PageTitle =
-                        $"Recently Submitted {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} for Reporting Period: {startDayOfReportingYearAsString} - {endDayOfReportingYearAsString}";
+                        $"Submitted {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} for Reporting Period: {startDayOfReportingYearAsString} - {endDayOfReportingYearAsString}";
                     break;
                 case ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.AllMyProjects:
                     PageTitle =


### PR DESCRIPTION
- added field definition methods to use for background job (when we cannot get the Tenant from the request URL);
- bug fixes for the 'My Projects requiring an update' and 'my recently submitted projects' grid