### PR TITLE
PF-2149: rework/bug fixes

### DIFF
--- a/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectModelExtensions.cs
@@ -799,14 +799,13 @@ namespace ProjectFirma.Web.Models
 
             var latestUpdateBatch = project.GetLatestUpdateBatch();
 
-            // no update and the reporting period is active
-            if (latestUpdateBatch == null && FirmaDateUtilities.LastReportingPeriodStartDate() <= DateTime.Today && DateTime.Today <= FirmaDateUtilities.LastReportingPeriodEndDate())
+            if (latestUpdateBatch == null)
             {
                 return true;
             }
 
-            // last update was not approved, or was approved outside the reporting period
-            if (latestUpdateBatch != null && (!latestUpdateBatch.IsApproved() || !(FirmaDateUtilities.LastReportingPeriodStartDate() <= latestUpdateBatch.LastUpdateDate && latestUpdateBatch.LastUpdateDate <= FirmaDateUtilities.LastReportingPeriodEndDate())))
+            // last update was not approved, or was approved before the reporting period start
+            if (!latestUpdateBatch.IsApproved() || latestUpdateBatch.LastUpdateDate.IsDateBefore(FirmaDateUtilities.LastReportingPeriodStartDate()))
             {
                 return true;
             }

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/EditProjectUpdateConfiguration.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/EditProjectUpdateConfiguration.cshtml
@@ -53,8 +53,8 @@
 @using (Html.BeginForm())
 {
     <div class="form-horizontal">
-        <p>Use this form to configure a reporting period for @ViewDataTyped.FieldDefinitionForProject.GetFieldDefinitionLabel().ToLower() updates and set up reminders to be sent to all @FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabelPluralized() with @ViewDataTyped.FieldDefinitionForProject.GetFieldDefinitionLabelPluralized().ToLower() requiring an update. @ViewDataTyped.FieldDefinitionForProject.GetFieldDefinitionLabel() updates can be made throughout the year regardless of whether there is an active reporting period.</p>
-        <p>A reporting period is required and can be any length of time within a year. You can change the reporting period throughout the year to support multiple reporting periods in one year. However if you change the period during an active reporting period, the reporting status of each @ViewDataTyped.FieldDefinitionForProject.GetFieldDefinitionLabel().ToLower() will be updated, which could be confusing to users.</p>
+        <p>Use this form to configure a reporting period for @ViewDataTyped.FieldDefinitionForProject.GetFieldDefinitionLabel() updates and set up reminders to be sent to all @FieldDefinitionEnum.ProjectPrimaryContact.ToType().GetFieldDefinitionLabelPluralized() with @ViewDataTyped.FieldDefinitionForProject.GetFieldDefinitionLabelPluralized() requiring an update. @ViewDataTyped.FieldDefinitionForProject.GetFieldDefinitionLabel() updates can be made throughout the year regardless of whether there is an active reporting period.</p>
+        <p>A reporting period is required and can be any length of time within a year. You can change the reporting period throughout the year to support multiple reporting periods in one year. However if you change the period during an active reporting period, the reporting status of each @ViewDataTyped.FieldDefinitionForProject.GetFieldDefinitionLabel() will be updated, which could be confusing to users.</p>
         @Html.ValidationSummary()
         <div class="form-group">
             <div class="col-xs-4 control-label">@Html.LabelWithSugarFor(m => m.ProjectUpdateKickOffDate)</div>
@@ -88,7 +88,7 @@
             <div class="col-xs-8">
                 @Html.CkEditorFor(m => m.ProjectUpdateKickOffIntroContent, CkEditorExtension.CkEditorToolbar.All, true, true, null)
                 <br/>
-                <p>The reminder email will also include a list of the recipient’s @(FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized().ToLower()) that require an update and do not have an update submitted yet. </p>
+                <p>The reminder email will also include a list of the recipient’s @(FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()) that require an update and do not have an update submitted yet. </p>
             </div>
         </div>
         <div class="form-group">

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/MyProjectsViewData.cs
@@ -64,7 +64,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
                     break;
                 case ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.MySubmittedProjects:
                     PageTitle =
-                        $"Submitted {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized()} Updates for Reporting Period: {startDayOfReportingYearAsString} - {endDayOfReportingYearAsString}";
+                        $"Submitted {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} Updates for Reporting Period: {startDayOfReportingYearAsString} - {endDayOfReportingYearAsString}";
                     break;
                 case ProjectUpdateStatusGridSpec.ProjectUpdateStatusFilterTypeEnum.AllMyProjects:
                     PageTitle =

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/ProjectUpdateStatusGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/ProjectUpdateStatusGridSpec.cs
@@ -51,7 +51,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
                     var projectUpdateState = x.GetLatestUpdateStateResilientToDuplicateUpdateBatches();
                     var latestApprovedUpdateBatch = x.GetLatestApprovedUpdateBatch();
                     if (projectUpdateState == null ||
-                        (projectUpdateState == ProjectUpdateState.Approved && latestApprovedUpdateBatch != null && !(FirmaDateUtilities.LastReportingPeriodStartDate() < latestApprovedUpdateBatch.LastUpdateDate && latestApprovedUpdateBatch.LastUpdateDate < FirmaDateUtilities.LastReportingPeriodEndDate())))
+                        (projectUpdateState == ProjectUpdateState.Approved && latestApprovedUpdateBatch != null && !latestApprovedUpdateBatch.LastUpdateDate.IsDateInRange(FirmaDateUtilities.LastReportingPeriodStartDate(), FirmaDateUtilities.LastReportingPeriodEndDate())))
                         return "Not Started";
 
                     return projectUpdateState.ToEnum.ToString();


### PR DESCRIPTION
- 'my projects requiring an update' grid should show all not submitted and not approved (after the last reporting period start date) project updates. 
- Fixed edge case of date comparison (should be using date only, not time). 
- Minor text changes.