### PR TITLE
PF-2301 - Improve footer's version info and add "data as of" in QA

### DIFF
--- a/Database/Tables/dbo.LastSQLServerDatabaseBackup.sql
+++ b/Database/Tables/dbo.LastSQLServerDatabaseBackup.sql
@@ -1,0 +1,23 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[LastSQLServerDatabaseBackup](
+	[LastSQLServerDatabaseBackupID] [int] IDENTITY(1,1) NOT NULL,
+	[BackupName] [nvarchar](128) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[UserName] [nvarchar](128) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[ServerName] [nvarchar](128) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[DatabaseName] [nvarchar](128) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[DatabaseVersion] [int] NULL,
+	[DatabaseCreationDate] [datetime] NULL,
+	[BackupSize] [numeric](20, 0) NULL,
+	[BackupStartDate] [datetime] NULL,
+	[BackupFinishDate] [datetime] NULL,
+	[MachineName] [nvarchar](128) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[Collation] [nvarchar](128) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[CompressedBackupSize] [bigint] NULL,
+ CONSTRAINT [PK_LastSQLServerDatabaseBackup] PRIMARY KEY NONCLUSTERED 
+(
+	[LastSQLServerDatabaseBackupID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]

--- a/Database/Utilities/RestoreDatabase.sql
+++ b/Database/Utilities/RestoreDatabase.sql
@@ -21,7 +21,118 @@ if (@@error != 0) goto failed
 exec sp_changedbowner 'sa'
 if (@@error != 0) goto failed
 
--- 4. put the ${db-name} database back into multi user mode
+-- 4. Retrieve the last backup information, and stash it in the restored database for later runtime reference
+
+DECLARE @LastBackupKeyValues TABLE
+	(
+		 BackupName nvarchar(128)
+		,BackupDescription nvarchar(255)
+		,BackupType smallint
+		,ExpirationDate datetime
+		,Compressed tinyint
+		,Position smallint
+		,DeviceType tinyint
+		,UserName nvarchar(128)
+		,ServerName nvarchar(128)
+		,DatabaseName nvarchar(128)
+		,DatabaseVersion int
+		,DatabaseCreationDate datetime
+		,BackupSize numeric(20,0)
+		,FirstLSN numeric(25,0)
+		,LastLSN numeric(25,0)
+		,CheckpointLSN numeric(25,0)
+		,DatabaseBackupLSN numeric(25,0)
+		,BackupStartDate datetime
+		,BackupFinishDate datetime
+		,SortOrder smallint
+		,CodePage smallint
+		,UnicodeLocaleId int
+		,UnicodeComparisonStyle int
+		,CompatibilityLevel tinyint
+		,SoftwareVendorId int
+		,SoftwareVersionMajor int
+		,SoftwareVersionMinor int
+		,SoftwareVersionBuild int
+		,MachineName nvarchar(128)
+		,Flags int
+		,BindingID uniqueidentifier
+		,RecoveryForkID uniqueidentifier
+		 --following columns introduced in SQL 2008
+		,Collation nvarchar(128)
+		,FamilyGUID uniqueidentifier
+		,HasBulkLoggedData bit
+		,IsSnapshot bit
+		,IsReadOnly bit
+		,IsSingleUser bit
+		,HasBackupChecksums bit
+		,IsDamaged bit
+		,BeginsLogChain bit
+		,HasIncompleteMetaData bit
+		,IsForceOffline bit
+		,IsCopyOnly bit
+		,FirstRecoveryForkID uniqueidentifier
+		,ForkPointLSN numeric(25,0)
+		,RecoveryModel nvarchar(60)
+		,DifferentialBaseLSN numeric(25,0)
+		,DifferentialBaseGUID uniqueidentifier
+		,BackupTypeDescription nvarchar(60)
+		,BackupSetGUID uniqueidentifier NULL 
+		,CompressedBackupSize bigint
+		--following columns introduced in SQL 2012
+		,Containment tinyint 
+		--following columns introduced in SQL 2014
+		,KeyAlgorithm nvarchar(32)
+		,EncryptorThumbprint varbinary(20)
+		,EncryptorType nvarchar(32)
+	);
+
+INSERT INTO @LastBackupKeyValues EXEC ('RESTORE HEADERONLY FROM DISK=''@DUMPFILE@''');
+
+-- This initial creation can be hotfixed out to prod then removed.
+--
+-- If removed, we should clear prior entries from the table at this point, so that there
+-- is only one entry at a time.
+use ${db-name}
+DROP TABLE IF EXISTS dbo.LastSQLServerDatabaseBackup;
+
+CREATE TABLE dbo.LastSQLServerDatabaseBackup
+(
+    LastSQLServerDatabaseBackupID [int] IDENTITY(1,1) NOT NULL,
+    BackupName nvarchar(128),
+    UserName nvarchar(128),
+    ServerName nvarchar(128),
+    DatabaseName nvarchar(128),
+    DatabaseVersion int,
+    DatabaseCreationDate datetime,
+    BackupSize numeric(20,0),
+    BackupStartDate datetime,
+    BackupFinishDate datetime,
+    MachineName nvarchar(128),
+    Collation nvarchar(128),
+    CompressedBackupSize bigint
+)
+
+ALTER TABLE dbo.LastSQLServerDatabaseBackup 
+ADD CONSTRAINT PK_LastSQLServerDatabaseBackup PRIMARY KEY NONCLUSTERED (LastSQLServerDatabaseBackupID);
+
+use ${db-name}
+insert into dbo.LastSQLServerDatabaseBackup
+select
+    lbkv.BackupName,
+    lbkv.UserName,
+    lbkv.ServerName,
+    lbkv.DatabaseName,
+    lbkv.DatabaseVersion,
+    lbkv.DatabaseCreationDate,
+    lbkv.BackupSize,
+    lbkv.BackupStartDate,
+    lbkv.BackupFinishDate,
+    lbkv.MachineName,
+    lbkv.Collation,
+    lbkv.CompressedBackupSize 
+    from @LastBackupKeyValues as lbkv
+
+-- 5. put the ${db-name} database back into multi user mode
 alter database ${db-name} set multi_user
 if (@@error != 0) goto failed
 

--- a/Source/ProjectFirma.Web/Common/HttpRequestStorage.cs
+++ b/Source/ProjectFirma.Web/Common/HttpRequestStorage.cs
@@ -60,20 +60,9 @@ namespace ProjectFirma.Web.Common
             set => SetValue(FirmaSessionKey, value);
         }
 
-        // Old way - accessed directly
-
-        //public static Person Person
-        //{
-        //    get => GetValueOrDefault(PersonKey, PersonModelExtensions.GetAnonymousSitkaUser);
-        //    set => SetValue(PersonKey, value);
-        //}
-
-        // New way - Accessed via current Session. Ultimately this may be able to be inlined
-
         public static Person Person
         {
             get => FirmaSession.Person;
-            //set => SetValue(PersonKey, value);
         }
 
         public static Tenant Tenant

--- a/Source/ProjectFirma.Web/Controllers/ClaimsIdentityHelper.cs
+++ b/Source/ProjectFirma.Web/Controllers/ClaimsIdentityHelper.cs
@@ -46,7 +46,7 @@ namespace ProjectFirma.Web.Controllers
                         return firmaSessionForRealPerson.Last();
                     }
                     // Otherwise, we could not find a FirmaSession for this person. Create one.
-                    var firmaSessionFromClaimsIdentity = new FirmaSession(personFromClaimsIdentity);
+                    var firmaSessionFromClaimsIdentity = new FirmaSession(HttpRequestStorage.DatabaseEntities, personFromClaimsIdentity);
 
                     // Only save if the Session if it being newly created
                     HttpRequestStorage.DatabaseEntities.AllFirmaSessions.Add(firmaSessionFromClaimsIdentity);
@@ -55,7 +55,7 @@ namespace ProjectFirma.Web.Controllers
                     return firmaSessionFromClaimsIdentity;
                 }
                 // Otherwise, anonymous user. We make a new session each time, which seems flawed - but not sure how else to handle yet. -- SLG
-                var firmaSessionForAnonymousPerson = FirmaSession.MakeEmptyFirmaSession(HttpRequestStorage.Tenant);
+                var firmaSessionForAnonymousPerson = FirmaSession.MakeEmptyFirmaSession(HttpRequestStorage.DatabaseEntities, HttpRequestStorage.Tenant);
                 return firmaSessionForAnonymousPerson;
             }
             catch (Exception ex)

--- a/Source/ProjectFirma.Web/Controllers/FirmaBaseController.cs
+++ b/Source/ProjectFirma.Web/Controllers/FirmaBaseController.cs
@@ -64,6 +64,10 @@ namespace ProjectFirma.Web.Controllers
         {
             var firmaSessionFromClaimsIdentity = ClaimsIdentityHelper.FirmaSessionFromClaimsIdentity(HttpContext.GetOwinContext().Authentication, CurrentTenant);
 
+            // We also need to wedge this in in certain contexts
+            firmaSessionFromClaimsIdentity.SetDatabaseEntities(HttpRequestStorage.DatabaseEntities);
+
+            // Use this session
             HttpRequestStorage.FirmaSession = firmaSessionFromClaimsIdentity;
             // we need to set this so that the save will know who the Person is
             HttpRequestStorage.DatabaseEntities.Person = firmaSessionFromClaimsIdentity.Person;

--- a/Source/ProjectFirma.Web/Controllers/ProjectFactSheetController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectFactSheetController.cs
@@ -38,7 +38,7 @@ namespace ProjectFirma.Web.Controllers
         {
             var firmaPage = FirmaPageTypeEnum.ManageProjectFactSheet.GetFirmaPage();
             var factSheetCustomTextFirmaPage = FirmaPageTypeEnum.FactSheetCustomText.GetFirmaPage();
-            var factSheetCustomTextViewData = new ViewPageContentViewData(factSheetCustomTextFirmaPage, false);
+            var factSheetCustomTextViewData = new ViewPageContentViewData(factSheetCustomTextFirmaPage, false, this.CurrentFirmaSession);
             var editCustomFactSheetTextUrl =  SitkaRoute<FirmaPageController>.BuildUrlFromExpression(t => t.EditInDialog(factSheetCustomTextFirmaPage));
             var deleteFactSheetLogoFileResourceUrl = new SitkaRoute<ProjectFactSheetController>(c => c.DeleteTenantFactSheetLogoFileResource()).BuildUrlFromExpression();
             var editFactSheetLogoUrl = new SitkaRoute<ProjectFactSheetController>(c => c.EditFactSheetLogo()).BuildUrlFromExpression();

--- a/Source/ProjectFirma.Web/FirmaOwinStartup.cs
+++ b/Source/ProjectFirma.Web/FirmaOwinStartup.cs
@@ -295,7 +295,7 @@ namespace ProjectFirma.Web
             else
             {
                 // Otherwise, we could not find a FirmaSession for this person. Create one.
-                var newFirmaSession = new FirmaSession(person);
+                var newFirmaSession = new FirmaSession(HttpRequestStorage.DatabaseEntities, person);
                 HttpRequestStorage.FirmaSession = newFirmaSession;
                 // Only save if session is being newly created
                 HttpRequestStorage.DatabaseEntities.AllFirmaSessions.Add(newFirmaSession);

--- a/Source/ProjectFirma.Web/Models/FirmaSessionModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/FirmaSessionModelExtensions.cs
@@ -40,7 +40,7 @@ namespace ProjectFirma.Web.Models
         /// <returns></returns>
         public static FirmaSession GetAnonymousFirmaSession()
         {
-            var anonymousFirmaSession = FirmaSession.MakeEmptyFirmaSession(HttpRequestStorage.Tenant);
+            var anonymousFirmaSession = FirmaSession.MakeEmptyFirmaSession(HttpRequestStorage.DatabaseEntities, HttpRequestStorage.Tenant);
             return anonymousFirmaSession;
         }
 

--- a/Source/ProjectFirma.Web/Models/FirmaTestWithContext.cs
+++ b/Source/ProjectFirma.Web/Models/FirmaTestWithContext.cs
@@ -19,7 +19,6 @@ Source code is available upon request via <support@sitkatech.com>.
 </license>
 -----------------------------------------------------------------------*/
 
-using System;
 using System.Linq;
 using ProjectFirma.Web.Common;
 using NUnit.Framework;
@@ -35,7 +34,7 @@ namespace ProjectFirmaModels.Models
             HttpRequestStorage.StartContextForTest();
             var randomPerson = HttpRequestStorage.DatabaseEntities.People.First();
             //HttpRequestStorage.Person = randomPerson;
-            HttpRequestStorage.FirmaSession = new FirmaSession(randomPerson);
+            HttpRequestStorage.FirmaSession = new FirmaSession(HttpRequestStorage.DatabaseEntities, randomPerson);
         }
 
         [TearDown]

--- a/Source/ProjectFirma.Web/Models/ProjectPerformanceMeasurePermissionsTest.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectPerformanceMeasurePermissionsTest.cs
@@ -370,7 +370,7 @@ namespace ProjectFirmaModels.Models
             }
 
             // Temp fake Session
-            var tempFirmaSession = new FirmaSession(user);
+            var tempFirmaSession = new FirmaSession(HttpRequestStorage.DatabaseEntities, user);
             Assert.That(projectCheckingFeature.HasPermission(tempFirmaSession, project).HasPermission == expectedPermission);
             project.ProjectOrganizations.Clear();
             user.Organization = originalUserOrg;
@@ -399,7 +399,7 @@ namespace ProjectFirmaModels.Models
             organizationToMakeUserTemporaryPrimaryContactOfImplementingOrg.PrimaryContactPersonID = user.PersonID;
 
             // Temp fake Session
-            var tempFirmaSession = new FirmaSession(user);
+            var tempFirmaSession = new FirmaSession(HttpRequestStorage.DatabaseEntities, user);
             Assert.That(projectCheckingFeature.HasPermission(tempFirmaSession, project).HasPermission == expectedPermission);
 
             user.Organization = originalUserOrg;

--- a/Source/ProjectFirma.Web/Views/FirmaViewData.cs
+++ b/Source/ProjectFirma.Web/Views/FirmaViewData.cs
@@ -119,8 +119,8 @@ namespace ProjectFirma.Web.Views
             ProjectFindUrl = SitkaRoute<ProjectController>.BuildUrlFromExpression(c => c.Find(string.Empty));
 
             var currentPersonCanManage = new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission;
-            ViewPageContentViewData = firmaPage != null ? new ViewPageContentViewData(firmaPage, currentPersonCanManage) : null;
-            CustomFooterViewData = new ViewPageContentViewData(FirmaPageTypeEnum.CustomFooter.GetFirmaPage(), currentPersonCanManage);
+            ViewPageContentViewData = firmaPage != null ? new ViewPageContentViewData(firmaPage, currentPersonCanManage, this.CurrentFirmaSession) : null;
+            CustomFooterViewData = new ViewPageContentViewData(FirmaPageTypeEnum.CustomFooter.GetFirmaPage(), currentPersonCanManage, this.CurrentFirmaSession);
             TenantName = MultiTenantHelpers.GetTenantName();
             TenantShortDisplayName = MultiTenantHelpers.GetTenantShortDisplayName();
             TenantBannerLogoUrl = MultiTenantHelpers.GetTenantBannerLogoUrl();

--- a/Source/ProjectFirma.Web/Views/Home/IndexViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Home/IndexViewData.cs
@@ -61,9 +61,9 @@ namespace ProjectFirma.Web.Views.Home
             Check.EnsureNotNull(firmaPageMapInfo, "firmaPageMapInfo not found; is one defined?");
             bool hasPermissionToManagePageMapInfo = new FirmaPageManageFeature().HasPermission(firmaSession, firmaPageMapInfo).HasPermission;
 
-            CustomHomePageTextViewData = new ViewPageContentViewData(firmaPageHomePage, hasPermissionToManageHomePage);
-            CustomHomePageAdditionalInfoTextViewData = new ViewPageContentViewData(firmaPageAdditionalInfo, hasPermissionToManageAdditionalInfo);
-            CustomHomePageMapTextViewData = new ViewPageContentViewData(firmaPageMapInfo, hasPermissionToManagePageMapInfo);
+            CustomHomePageTextViewData = new ViewPageContentViewData(firmaPageHomePage, hasPermissionToManageHomePage, this.CurrentFirmaSession);
+            CustomHomePageAdditionalInfoTextViewData = new ViewPageContentViewData(firmaPageAdditionalInfo, hasPermissionToManageAdditionalInfo, this.CurrentFirmaSession);
+            CustomHomePageMapTextViewData = new ViewPageContentViewData(firmaPageMapInfo, hasPermissionToManagePageMapInfo, this.CurrentFirmaSession);
             FeaturedProjectsViewData = featuredProjectsViewData;
             FullMapUrl = SitkaRoute<ResultsController>.BuildUrlFromExpression(x => x.ProjectMap());
             ProjectLocationsMapViewData = projectLocationsMapViewData;

--- a/Source/ProjectFirma.Web/Views/MapLayer/IndexViewData.cs
+++ b/Source/ProjectFirma.Web/Views/MapLayer/IndexViewData.cs
@@ -58,7 +58,7 @@ namespace ProjectFirma.Web.Views.MapLayer
             NewUrl = SitkaRoute<MapLayerController>.BuildUrlFromExpression(x => x.New());
 
             var currentPersonCanManage = new FirmaPageManageFeature().HasPermission(currentFirmaSession, internalMapLayersFirmaPage).HasPermission;
-            InternalMapLayersViewPageContentViewData = new ViewPageContentViewData(internalMapLayersFirmaPage, currentPersonCanManage);
+            InternalMapLayersViewPageContentViewData = new ViewPageContentViewData(internalMapLayersFirmaPage, currentPersonCanManage, currentFirmaSession);
 
             GeospatialAreaMapLayerGridSpec = new GeospatialAreaMapLayerGridSpec(userCanManage)
             {

--- a/Source/ProjectFirma.Web/Views/Project/BackwardLookingFactSheetViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/BackwardLookingFactSheetViewData.cs
@@ -135,7 +135,7 @@ namespace ProjectFirma.Web.Views.Project
             TaxonomyBranchName = project.TaxonomyLeaf == null ? $"{FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()} Taxonomy Not Set" : project.TaxonomyLeaf.TaxonomyBranch.GetDisplayName();
             TaxonomyLeafDisplayName = FieldDefinitionEnum.TaxonomyLeaf.ToType().GetFieldDefinitionLabel();
             PrimaryContactPerson = project.GetPrimaryContact();
-            CustomFactSheetPageTextViewData = new ViewPageContentViewData(firmaPageFactSheet, false);
+            CustomFactSheetPageTextViewData = new ViewPageContentViewData(firmaPageFactSheet, false, currentFirmaSession);
             TechnicalAssistanceParameters = technicalAssistanceParameters;
             TechnicalAssistanceRequests = project.TechnicalAssistanceRequests.ToList();
 

--- a/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ForwardLookingFactSheetViewData.cs
@@ -155,7 +155,7 @@ namespace ProjectFirma.Web.Views.Project
             TargetedFunding = Project.GetTargetedFunding().ToStringCurrency();
 
             FundingBudget = project.ProjectFundingSourceBudgets.Any() ? project.ProjectFundingSourceBudgets.Sum(x => x.TargetedAmount).ToStringCurrency() : ViewUtilities.Unknown;
-            CustomFactSheetTextViewData = new ViewPageContentViewData(firmaPageFactSheetCustomText, false);
+            CustomFactSheetTextViewData = new ViewPageContentViewData(firmaPageFactSheetCustomText, false, currentFirmaSession);
             TechnicalAssistanceParameters = technicalAssistanceParameters;
             TechnicalAssistanceRequests = project.TechnicalAssistanceRequests.ToList();
 

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoricViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsEnterHistoricViewData.cs
@@ -37,13 +37,13 @@ namespace ProjectFirma.Web.Views.ProjectCreate
         public InstructionsEnterHistoricViewData(FirmaSession currentFirmaSession, ProjectFirmaModels.Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentFirmaSession, "Instructions", SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsEnterHistoric(null)))
         {
             PageTitle = $"Add {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()}";
-            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission);
+            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission, currentFirmaSession);
             IsNewProjectCreate = isNewProjectCreate;
         }
 
         public InstructionsEnterHistoricViewData(FirmaSession currentFirmaSession, ProjectFirmaModels.Models.Project project, ProposalSectionsStatus proposalSectionsStatus, ProjectFirmaModels.Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentFirmaSession, project, "Instructions", proposalSectionsStatus)
         {
-            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission);
+            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission, currentFirmaSession);
             IsNewProjectCreate = isNewProjectCreate;
         }
     }

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposalViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/InstructionsProposalViewData.cs
@@ -38,13 +38,13 @@ namespace ProjectFirma.Web.Views.ProjectCreate
         public InstructionsProposalViewData(FirmaSession currentFirmaSession, ProjectFirmaModels.Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentFirmaSession, "Instructions", SitkaRoute<ProjectCreateController>.BuildUrlFromExpression(x => x.InstructionsProposal(null)))
         {
             PageTitle = $"Propose {FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel()}";
-            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission);
+            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission, currentFirmaSession);
             IsNewProjectCreate = isNewProjectCreate;
         }
 
         public InstructionsProposalViewData(FirmaSession currentFirmaSession, ProjectFirmaModels.Models.Project project, ProposalSectionsStatus proposalSectionsStatus, ProjectFirmaModels.Models.FirmaPage firmaPage, bool isNewProjectCreate) : base(currentFirmaSession, project,  "Instructions", proposalSectionsStatus)
         {
-            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission);
+            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission, currentFirmaSession);
             IsNewProjectCreate = isNewProjectCreate;
         }
     }

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/InstructionsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/InstructionsViewData.cs
@@ -37,7 +37,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
             ProjectUpdateStatus projectUpdateStatus, ProjectFirmaModels.Models.FirmaPage firmaPage) : base(currentFirmaSession, projectUpdateBatch, projectUpdateStatus, new List<string>(), "Instructions")
         {
             PerformanceMeasuresUrl = SitkaRoute<PerformanceMeasureController>.BuildUrlFromExpression(x => x.Index());
-            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission);
+            InstructionsViewPageContentViewData = new ViewPageContentViewData(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission, currentFirmaSession);
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/TechnicalAssistanceRequestsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/TechnicalAssistanceRequestsViewData.cs
@@ -41,7 +41,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
         {
             Check.EnsureNotNull(firmaPage, "The Firma Page for this section is not found; is one defined?");
             bool hasPermissionToManageFirmaPage = new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission;
-            TechnicalAssistanceInstructionsViewData = new ViewPageContentViewData(firmaPage, hasPermissionToManageFirmaPage);
+            TechnicalAssistanceInstructionsViewData = new ViewPageContentViewData(firmaPage, hasPermissionToManageFirmaPage, currentFirmaSession);
             UserCanAllocate = new ProjectUpdateAdminFeatureWithProjectContext().HasPermission(currentFirmaSession, projectUpdateBatch.Project).HasPermission;
             ViewDataForAngular = new TechnicalAssistanceRequestsViewDataForAngular(projectUpdateBatch.ProjectID, technicalAssistanceTypes, fiscalYearStrings, personSimples);
             SectionCommentsViewData = new SectionCommentsViewData(projectUpdateBatch.TechnicalAssistanceRequestsComment, projectUpdateBatch.IsReturned());

--- a/Source/ProjectFirma.Web/Views/Shared/DisplayPageContentViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Shared/DisplayPageContentViewData.cs
@@ -31,13 +31,13 @@ namespace ProjectFirma.Web.Views.Shared
         public DisplayPageContentViewData(FirmaSession currentFirmaSession, ProjectFirmaModels.Models.FirmaPage firmaPage, bool showEditButton) : base(currentFirmaSession)
         {
             PageTitle = firmaPage.GetFirmaPageDisplayName();
-            ViewWholePageContentViewData = new ViewPageContentViewData(firmaPage, showEditButton);
+            ViewWholePageContentViewData = new ViewPageContentViewData(firmaPage, showEditButton, currentFirmaSession);
         }
 
         public DisplayPageContentViewData(FirmaSession currentFirmaSession, ProjectFirmaModels.Models.CustomPage customPage, bool showEditButton) : base(currentFirmaSession)
         {
             PageTitle = customPage.GetFirmaPageDisplayName();
-            ViewWholePageContentViewData = new ViewPageContentViewData(customPage, showEditButton);
+            ViewWholePageContentViewData = new ViewPageContentViewData(customPage, showEditButton, currentFirmaSession);
             DisplayDocumentLibraryViewData = new DisplayDocumentLibraryViewData(customPage, currentFirmaSession);
 
         }

--- a/Source/ProjectFirma.Web/Views/Shared/NavAndHeaderLayout.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/NavAndHeaderLayout.cshtml
@@ -300,7 +300,8 @@ Source code is available upon request via <support@sitkatech.com>.
             Source code is available on <a href="https://github.com/sitkatech/projectfirma">GitHub</a>.
         </p>
         <p class="text-center">
-            Copyright (C) 2020 <a href="http://trpa.org">Tahoe Regional Planning Agency</a> and <a href="http://www.sitkatech.com">Sitka Technology Group</a> | Version @FirmaWebConfiguration.WebApplicationVersionInfo.Value.ApplicationVersion | Compiled @FirmaWebConfiguration.WebApplicationVersionInfo.Value.DateCompiled.ToString("yyyy-MM-dd HH:mm:ss") | PID @Process.GetCurrentProcess().Id
+           @*Copyright (C) @ViewDataTyped.CustomFooterViewData.CopyrightCalendarYear <a href="http://trpa.org">Tahoe Regional Planning Agency</a> and <a href="http://www.sitkatech.com">Sitka Technology Group</a> | Version @FirmaWebConfiguration.WebApplicationVersionInfo.Value.ApplicationVersion | Compiled @FirmaWebConfiguration.WebApplicationVersionInfo.Value.DateCompiled.ToString("yyyy-MM-dd HH:mm:ss") | PID @Process.GetCurrentProcess().Id*@
+           Copyright (C) @ViewDataTyped.CustomFooterViewData.CopyrightCalendarYear <a href="http://trpa.org">Tahoe Regional Planning Agency</a> and <a href="http://www.sitkatech.com">Sitka Technology Group</a> | Code last updated (compiled) at @FirmaWebConfiguration.WebApplicationVersionInfo.Value.DateCompiled.ToString("yyyy-MM-dd HH:mm:ss"). @ViewDataTyped.CustomFooterViewData.OptionalSQLDatabaseBackupFromProductionDateString
         </p>
 
     </div>

--- a/Source/ProjectFirma.Web/Views/Shared/ViewPageContentViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Shared/ViewPageContentViewData.cs
@@ -1,4 +1,5 @@
-﻿using System.Web;
+﻿using System;
+using System.Web;
 using ProjectFirma.Web.Common;
 using ProjectFirma.Web.Controllers;
 using ProjectFirmaModels.Models;
@@ -8,14 +9,16 @@ namespace ProjectFirma.Web.Views.Shared
 {
     public class ViewPageContentViewData
     {
+        public readonly FirmaSession CurrentFirmaSession;
         public readonly HtmlString FirmaPageContentHtmlString;
         public readonly string FirmaPageDisplayName;
         public readonly bool ShowEditButton;
         public readonly bool HasPageContent;
         public readonly string EditPageContentUrl;
 
-        public ViewPageContentViewData(ProjectFirmaModels.Models.FirmaPage firmaPage, bool showEditButton)
+        public ViewPageContentViewData(ProjectFirmaModels.Models.FirmaPage firmaPage, bool showEditButton, FirmaSession currentFirmaSession)
         {
+            CurrentFirmaSession = currentFirmaSession;
             FirmaPageContentHtmlString = firmaPage.GetFirmaPageContentHtmlString();
             FirmaPageDisplayName = firmaPage.GetFirmaPageDisplayName();
             ShowEditButton = showEditButton;
@@ -23,8 +26,9 @@ namespace ProjectFirma.Web.Views.Shared
             EditPageContentUrl = SitkaRoute<FirmaPageController>.BuildUrlFromExpression(t => t.EditInDialog(firmaPage));
         }
 
-        public ViewPageContentViewData(ProjectFirmaModels.Models.CustomPage customPage, bool showEditButton)
+        public ViewPageContentViewData(ProjectFirmaModels.Models.CustomPage customPage, bool showEditButton, FirmaSession currentFirmaSession)
         {
+            CurrentFirmaSession = currentFirmaSession;
             FirmaPageContentHtmlString = customPage.GetFirmaPageContentHtmlString();
             FirmaPageDisplayName = customPage.GetFirmaPageDisplayName();
             ShowEditButton = showEditButton;
@@ -34,6 +38,7 @@ namespace ProjectFirma.Web.Views.Shared
 
         public ViewPageContentViewData(GeospatialAreaType geospatialAreaType, FirmaSession currentFirmaSession)
         {
+            CurrentFirmaSession = currentFirmaSession;
             FirmaPageContentHtmlString = geospatialAreaType.GetFirmaPageContentHtmlString();
             FirmaPageDisplayName = geospatialAreaType.GetFirmaPageDisplayName();
             ShowEditButton = new GeospatialAreaManageFeature().HasPermissionByFirmaSession(currentFirmaSession);
@@ -42,6 +47,7 @@ namespace ProjectFirma.Web.Views.Shared
         }
         public ViewPageContentViewData(ProjectFirmaModels.Models.Organization organization, FirmaSession currentFirmaSession)
         {
+            CurrentFirmaSession = currentFirmaSession;
             FirmaPageContentHtmlString = organization.GetFirmaPageContentHtmlString();
             FirmaPageDisplayName = organization.GetFirmaPageDisplayName();
             ShowEditButton = new OrganizationBackgroundEditFeature().HasPermission(currentFirmaSession, organization).HasPermission;
@@ -51,6 +57,7 @@ namespace ProjectFirma.Web.Views.Shared
 
         public ViewPageContentViewData(ProjectFirmaModels.Models.GeospatialArea geospatialArea, FirmaSession currentFirmaSession)
         {
+            CurrentFirmaSession = currentFirmaSession;
             FirmaPageContentHtmlString = geospatialArea.GetFirmaPageContentHtmlString();
             FirmaPageDisplayName = geospatialArea.GetFirmaPageDisplayName();
             ShowEditButton = new GeospatialAreaManageFeature().HasPermissionByFirmaSession(currentFirmaSession);
@@ -59,8 +66,42 @@ namespace ProjectFirma.Web.Views.Shared
         }
 
         public ViewPageContentViewData(ProjectFirmaModels.Models.FirmaPage firmaPage, FirmaSession currentFirmaSession)
-            : this(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission)
+            : this(firmaPage, new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission, currentFirmaSession)
         {
+        }
+
+        public int CopyrightCalendarYear
+        {
+            get { return DateTime.Now.Year; }
+        }
+
+        // ReSharper disable once InconsistentNaming
+        public string OptionalSQLDatabaseBackupFromProductionDateString
+        {
+            get
+            {
+                // This string is not shown in Prod, only QA and Localhost.
+                // (Prod is always assumed to be current and definitive, and not a backup of anything else.)
+                if (FirmaWebConfiguration.FirmaEnvironment.FirmaEnvironmentType == FirmaEnvironmentType.Prod)
+                {
+                    return string.Empty;
+                }
+
+                // An obviously fake date is shown if there are issues with the session. This value isn't
+                // so crucial that we'd want to blow up if something went wrong with retrieving it.
+                DateTime lastProductionDatabaseLoadTime = new DateTime(1111,11,11);
+
+                // If we do have a valid session, we retrieve the last Backup's finish date.
+                if (CurrentFirmaSession?.LastSqlServerDatabaseBackupInfo != null)
+                {
+                    // ReSharper disable once PossibleInvalidOperationException
+                    lastProductionDatabaseLoadTime = this.CurrentFirmaSession.LastSqlServerDatabaseBackupInfo.BackupFinishDate.Value;
+                }
+
+                string lastProductionDatabaseLoadTimeString = lastProductionDatabaseLoadTime.ToString("yyyy-MM-dd HH:mm:ss");
+
+                return $"Data from Production environment as of {lastProductionDatabaseLoadTimeString}.";
+            }
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/SiteMonitor/SiteMonitorNagios.cshtml
+++ b/Source/ProjectFirma.Web/Views/SiteMonitor/SiteMonitorNagios.cshtml
@@ -18,6 +18,7 @@
     Source code is available upon request via <support@sitkatech.com>.
     </license>
     -----------------------------------------------------------------------*@
+@using System.Diagnostics
 @inherits ProjectFirma.Web.Views.SiteMonitor.SiteMonitorNagios
 
 <div class="panel panelFirma">
@@ -52,6 +53,9 @@
         </ul>
         } 
     } 
+<div style="font-weight: bold">
+   Web Process PID: @Process.GetCurrentProcess().Id
+</div>
 </div>
 
 <div id="MachineReadableNagiosOutput">

--- a/Source/ProjectFirma.Web/Views/TechnicalAssistanceRequest/EditTechnicalAssistanceRequestsViewData.cs
+++ b/Source/ProjectFirma.Web/Views/TechnicalAssistanceRequest/EditTechnicalAssistanceRequestsViewData.cs
@@ -41,13 +41,12 @@ namespace ProjectFirma.Web.Views.TechnicalAssistanceRequest
         {
             Check.EnsureNotNull(firmaPage, "The Firma Page for this section is not found; is one defined?");
             bool hasPermissionToManageFirmaPage = new FirmaPageManageFeature().HasPermission(currentFirmaSession, firmaPage).HasPermission;
-            TechnicalAssistanceInstructionsViewData = new ViewPageContentViewData(firmaPage, hasPermissionToManageFirmaPage);
+            TechnicalAssistanceInstructionsViewData = new ViewPageContentViewData(firmaPage, hasPermissionToManageFirmaPage, currentFirmaSession);
             ProjectID = project.ProjectID;
             TechnicalAssistanceTypes = technicalAssistanceTypes;
             FiscalYearStrings = fiscalYearStrings;
             PersonSimples = personSimples;
             UserCanAllocate = new ProjectUpdateAdminFeatureWithProjectContext().HasPermission(currentFirmaSession, project).HasPermission;
-
         }
     }
 }

--- a/Source/ProjectFirmaModels/Models/Generated/DatabaseEntities.Context.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/DatabaseEntities.Context.Binding.cs
@@ -88,6 +88,7 @@ namespace ProjectFirmaModels.Models
             modelBuilder.Configurations.Add(new GeospatialAreaPerformanceMeasureReportingPeriodTargetConfiguration());
             modelBuilder.Configurations.Add(new GeospatialAreaTypeConfiguration());
             modelBuilder.Configurations.Add(new ImportExternalProjectStagingConfiguration());
+            modelBuilder.Configurations.Add(new LastSQLServerDatabaseBackupConfiguration());
             modelBuilder.Configurations.Add(new MatchMakerAreaOfInterestLocationConfiguration());
             modelBuilder.Configurations.Add(new MatchmakerKeywordConfiguration());
             modelBuilder.Configurations.Add(new MatchmakerOrganizationClassificationConfiguration());
@@ -297,6 +298,7 @@ namespace ProjectFirmaModels.Models
         public virtual IQueryable<GeospatialAreaType> GeospatialAreaTypes { get { return AllGeospatialAreaTypes.Where(x => x.TenantID == TenantID); } }
         public virtual DbSet<ImportExternalProjectStaging> AllImportExternalProjectStagings { get; set; }
         public virtual IQueryable<ImportExternalProjectStaging> ImportExternalProjectStagings { get { return AllImportExternalProjectStagings.Where(x => x.TenantID == TenantID); } }
+        public virtual DbSet<LastSQLServerDatabaseBackup> LastSQLServerDatabaseBackups { get; set; }
         public virtual DbSet<MatchMakerAreaOfInterestLocation> AllMatchMakerAreaOfInterestLocations { get; set; }
         public virtual IQueryable<MatchMakerAreaOfInterestLocation> MatchMakerAreaOfInterestLocations { get { return AllMatchMakerAreaOfInterestLocations.Where(x => x.TenantID == TenantID); } }
         public virtual DbSet<MatchmakerKeyword> AllMatchmakerKeywords { get; set; }
@@ -753,6 +755,9 @@ namespace ProjectFirmaModels.Models
 
                 case "ImportExternalProjectStaging":
                     return ImportExternalProjectStagings.GetImportExternalProjectStaging(primaryKey);
+
+                case "LastSQLServerDatabaseBackup":
+                    return LastSQLServerDatabaseBackups.GetLastSQLServerDatabaseBackup(primaryKey);
 
                 case "MatchMakerAreaOfInterestLocation":
                     return MatchMakerAreaOfInterestLocations.GetMatchMakerAreaOfInterestLocation(primaryKey);

--- a/Source/ProjectFirmaModels/Models/Generated/LastSQLServerDatabaseBackup.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/LastSQLServerDatabaseBackup.Binding.cs
@@ -1,0 +1,132 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[LastSQLServerDatabaseBackup]
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using System.Data.Entity.Spatial;
+using System.Linq;
+using System.Web;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    // Table [dbo].[LastSQLServerDatabaseBackup] is NOT multi-tenant, so is attributed as ICanDeleteFull
+    [Table("[dbo].[LastSQLServerDatabaseBackup]")]
+    public partial class LastSQLServerDatabaseBackup : IHavePrimaryKey, ICanDeleteFull
+    {
+        /// <summary>
+        /// Default Constructor; only used by EF
+        /// </summary>
+        protected LastSQLServerDatabaseBackup()
+        {
+
+        }
+
+        /// <summary>
+        /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
+        /// </summary>
+        public LastSQLServerDatabaseBackup(int lastSQLServerDatabaseBackupID, string backupName, string userName, string serverName, string databaseName, int? databaseVersion, DateTime? databaseCreationDate, decimal? backupSize, DateTime? backupStartDate, DateTime? backupFinishDate, string machineName, string collation, long? compressedBackupSize) : this()
+        {
+            this.LastSQLServerDatabaseBackupID = lastSQLServerDatabaseBackupID;
+            this.BackupName = backupName;
+            this.UserName = userName;
+            this.ServerName = serverName;
+            this.DatabaseName = databaseName;
+            this.DatabaseVersion = databaseVersion;
+            this.DatabaseCreationDate = databaseCreationDate;
+            this.BackupSize = backupSize;
+            this.BackupStartDate = backupStartDate;
+            this.BackupFinishDate = backupFinishDate;
+            this.MachineName = machineName;
+            this.Collation = collation;
+            this.CompressedBackupSize = compressedBackupSize;
+        }
+
+
+
+        /// <summary>
+        /// Creates a "blank" object of this type and populates primitives with defaults
+        /// </summary>
+        public static LastSQLServerDatabaseBackup CreateNewBlank()
+        {
+            return new LastSQLServerDatabaseBackup();
+        }
+
+        /// <summary>
+        /// Does this object have any dependent objects? (If it does have dependent objects, these would need to be deleted before this object could be deleted.)
+        /// </summary>
+        /// <returns></returns>
+        public bool HasDependentObjects()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Active Dependent type names of this object
+        /// </summary>
+        public List<string> DependentObjectNames() 
+        {
+            var dependentObjects = new List<string>();
+            
+            return dependentObjects.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// Dependent type names of this entity
+        /// </summary>
+        public static readonly List<string> DependentEntityTypeNames = new List<string> {typeof(LastSQLServerDatabaseBackup).Name};
+
+
+        /// <summary>
+        /// Delete just the entity 
+        /// </summary>
+        public void Delete(DatabaseEntities dbContext)
+        {
+            dbContext.LastSQLServerDatabaseBackups.Remove(this);
+        }
+        
+        /// <summary>
+        /// Delete entity plus all children
+        /// </summary>
+        public void DeleteFull(DatabaseEntities dbContext)
+        {
+            
+            Delete(dbContext);
+        }
+
+        [Key]
+        public int LastSQLServerDatabaseBackupID { get; set; }
+        public string BackupName { get; set; }
+        public string UserName { get; set; }
+        public string ServerName { get; set; }
+        public string DatabaseName { get; set; }
+        public int? DatabaseVersion { get; set; }
+        public DateTime? DatabaseCreationDate { get; set; }
+        public decimal? BackupSize { get; set; }
+        public DateTime? BackupStartDate { get; set; }
+        public DateTime? BackupFinishDate { get; set; }
+        public string MachineName { get; set; }
+        public string Collation { get; set; }
+        public long? CompressedBackupSize { get; set; }
+        [NotMapped]
+        public int PrimaryKey { get { return LastSQLServerDatabaseBackupID; } set { LastSQLServerDatabaseBackupID = value; } }
+
+
+
+        public static class FieldLengths
+        {
+            public const int BackupName = 128;
+            public const int UserName = 128;
+            public const int ServerName = 128;
+            public const int DatabaseName = 128;
+            public const int MachineName = 128;
+            public const int Collation = 128;
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/LastSQLServerDatabaseBackup.DatabaseContextExtensions.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/LastSQLServerDatabaseBackup.DatabaseContextExtensions.cs
@@ -1,0 +1,53 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[LastSQLServerDatabaseBackup]
+using System.Collections.Generic;
+using System.Linq;
+using Z.EntityFramework.Plus;
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public static partial class DatabaseContextExtensions
+    {
+        public static LastSQLServerDatabaseBackup GetLastSQLServerDatabaseBackup(this IQueryable<LastSQLServerDatabaseBackup> lastSQLServerDatabaseBackups, int lastSQLServerDatabaseBackupID)
+        {
+            var lastSQLServerDatabaseBackup = lastSQLServerDatabaseBackups.SingleOrDefault(x => x.LastSQLServerDatabaseBackupID == lastSQLServerDatabaseBackupID);
+            Check.RequireNotNullThrowNotFound(lastSQLServerDatabaseBackup, "LastSQLServerDatabaseBackup", lastSQLServerDatabaseBackupID);
+            return lastSQLServerDatabaseBackup;
+        }
+
+        // Delete using an IDList (Firma style)
+        public static void DeleteLastSQLServerDatabaseBackup(this IQueryable<LastSQLServerDatabaseBackup> lastSQLServerDatabaseBackups, List<int> lastSQLServerDatabaseBackupIDList)
+        {
+            if(lastSQLServerDatabaseBackupIDList.Any())
+            {
+                lastSQLServerDatabaseBackups.Where(x => lastSQLServerDatabaseBackupIDList.Contains(x.LastSQLServerDatabaseBackupID)).Delete();
+            }
+        }
+
+        // Delete using an object list (Firma style)
+        public static void DeleteLastSQLServerDatabaseBackup(this IQueryable<LastSQLServerDatabaseBackup> lastSQLServerDatabaseBackups, ICollection<LastSQLServerDatabaseBackup> lastSQLServerDatabaseBackupsToDelete)
+        {
+            if(lastSQLServerDatabaseBackupsToDelete.Any())
+            {
+                var lastSQLServerDatabaseBackupIDList = lastSQLServerDatabaseBackupsToDelete.Select(x => x.LastSQLServerDatabaseBackupID).ToList();
+                lastSQLServerDatabaseBackups.Where(x => lastSQLServerDatabaseBackupIDList.Contains(x.LastSQLServerDatabaseBackupID)).Delete();
+            }
+        }
+
+        public static void DeleteLastSQLServerDatabaseBackup(this IQueryable<LastSQLServerDatabaseBackup> lastSQLServerDatabaseBackups, int lastSQLServerDatabaseBackupID)
+        {
+            DeleteLastSQLServerDatabaseBackup(lastSQLServerDatabaseBackups, new List<int> { lastSQLServerDatabaseBackupID });
+        }
+
+        public static void DeleteLastSQLServerDatabaseBackup(this IQueryable<LastSQLServerDatabaseBackup> lastSQLServerDatabaseBackups, LastSQLServerDatabaseBackup lastSQLServerDatabaseBackupToDelete)
+        {
+            DeleteLastSQLServerDatabaseBackup(lastSQLServerDatabaseBackups, new List<LastSQLServerDatabaseBackup> { lastSQLServerDatabaseBackupToDelete });
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/LastSQLServerDatabaseBackupConfiguration.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/LastSQLServerDatabaseBackupConfiguration.Binding.cs
@@ -1,0 +1,34 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: [dbo].[LastSQLServerDatabaseBackup]
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity.ModelConfiguration;
+
+namespace ProjectFirmaModels.Models
+{
+    public class LastSQLServerDatabaseBackupConfiguration : EntityTypeConfiguration<LastSQLServerDatabaseBackup>
+    {
+        public LastSQLServerDatabaseBackupConfiguration() : this("dbo"){}
+
+        public LastSQLServerDatabaseBackupConfiguration(string schema)
+        {
+            ToTable("LastSQLServerDatabaseBackup", schema);
+            HasKey(x => x.LastSQLServerDatabaseBackupID);
+            Property(x => x.LastSQLServerDatabaseBackupID).HasColumnName(@"LastSQLServerDatabaseBackupID").HasColumnType("int").IsRequired().HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
+            Property(x => x.BackupName).HasColumnName(@"BackupName").HasColumnType("nvarchar").IsOptional().HasMaxLength(128);
+            Property(x => x.UserName).HasColumnName(@"UserName").HasColumnType("nvarchar").IsOptional().HasMaxLength(128);
+            Property(x => x.ServerName).HasColumnName(@"ServerName").HasColumnType("nvarchar").IsOptional().HasMaxLength(128);
+            Property(x => x.DatabaseName).HasColumnName(@"DatabaseName").HasColumnType("nvarchar").IsOptional().HasMaxLength(128);
+            Property(x => x.DatabaseVersion).HasColumnName(@"DatabaseVersion").HasColumnType("int").IsOptional();
+            Property(x => x.DatabaseCreationDate).HasColumnName(@"DatabaseCreationDate").HasColumnType("datetime").IsOptional();
+            Property(x => x.BackupSize).HasColumnName(@"BackupSize").HasColumnType("decimal").IsOptional();
+            Property(x => x.BackupStartDate).HasColumnName(@"BackupStartDate").HasColumnType("datetime").IsOptional();
+            Property(x => x.BackupFinishDate).HasColumnName(@"BackupFinishDate").HasColumnType("datetime").IsOptional();
+            Property(x => x.MachineName).HasColumnName(@"MachineName").HasColumnType("nvarchar").IsOptional().HasMaxLength(128);
+            Property(x => x.Collation).HasColumnName(@"Collation").HasColumnType("nvarchar").IsOptional().HasMaxLength(128);
+            Property(x => x.CompressedBackupSize).HasColumnName(@"CompressedBackupSize").HasColumnType("bigint").IsOptional();
+
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/Models/Generated/LastSQLServerDatabaseBackupPrimaryKey.Binding.cs
+++ b/Source/ProjectFirmaModels/Models/Generated/LastSQLServerDatabaseBackupPrimaryKey.Binding.cs
@@ -1,0 +1,27 @@
+//  IMPORTANT:
+//  This file is generated. Your changes will be lost.
+//  Use the corresponding partial class for customizations.
+//  Source Table: dbo.LastSQLServerDatabaseBackup
+using CodeFirstStoreFunctions;
+using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
+using LtInfo.Common.Models;
+
+namespace ProjectFirmaModels.Models
+{
+    public class LastSQLServerDatabaseBackupPrimaryKey : LtInfo.Common.EntityModelBinding.LtInfoEntityPrimaryKey<LastSQLServerDatabaseBackup>
+    {
+        public LastSQLServerDatabaseBackupPrimaryKey(int primaryKeyValue) : base(primaryKeyValue){}
+        public LastSQLServerDatabaseBackupPrimaryKey(LastSQLServerDatabaseBackup lastSQLServerDatabaseBackup) : base(lastSQLServerDatabaseBackup){}
+
+        public static implicit operator LastSQLServerDatabaseBackupPrimaryKey(int primaryKeyValue)
+        {
+            return new LastSQLServerDatabaseBackupPrimaryKey(primaryKeyValue);
+        }
+
+        public static implicit operator LastSQLServerDatabaseBackupPrimaryKey(LastSQLServerDatabaseBackup lastSQLServerDatabaseBackup)
+        {
+            return new LastSQLServerDatabaseBackupPrimaryKey(lastSQLServerDatabaseBackup);
+        }
+    }
+}

--- a/Source/ProjectFirmaModels/ProjectFirmaModels.csproj
+++ b/Source/ProjectFirmaModels/ProjectFirmaModels.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -251,6 +251,10 @@
     <Compile Include="Models\Generated\ImportExternalProjectStaging.DatabaseContextExtensions.cs" />
     <Compile Include="Models\Generated\ImportExternalProjectStagingConfiguration.Binding.cs" />
     <Compile Include="Models\Generated\ImportExternalProjectStagingPrimaryKey.Binding.cs" />
+    <Compile Include="Models\Generated\LastSQLServerDatabaseBackup.Binding.cs" />
+    <Compile Include="Models\Generated\LastSQLServerDatabaseBackup.DatabaseContextExtensions.cs" />
+    <Compile Include="Models\Generated\LastSQLServerDatabaseBackupConfiguration.Binding.cs" />
+    <Compile Include="Models\Generated\LastSQLServerDatabaseBackupPrimaryKey.Binding.cs" />
     <Compile Include="Models\Generated\MatchMakerAreaOfInterestLocation.Binding.cs" />
     <Compile Include="Models\Generated\MatchMakerAreaOfInterestLocation.DatabaseContextExtensions.cs" />
     <Compile Include="Models\Generated\MatchMakerAreaOfInterestLocationConfiguration.Binding.cs" />

--- a/Source/ProjectFirmaModels/UnitTestCommon/TestFirmaSession.cs
+++ b/Source/ProjectFirmaModels/UnitTestCommon/TestFirmaSession.cs
@@ -11,13 +11,13 @@ namespace ProjectFirmaModels.UnitTestCommon
                 var tenant = TestTenant.Get();
                 var person = TestPerson.Create(tenant);
 
-                var firmaSession = new FirmaSession(person);
+                var firmaSession = new FirmaSession(null, person);
                 return firmaSession;
             }
 
             public static FirmaSession Create(Person person)
             {
-                var firmaSession = new FirmaSession(person);
+                var firmaSession = new FirmaSession(null, person);
                 return firmaSession;
             }
         }


### PR DESCRIPTION
This seems to work, but the futzing with the session and getting access to LastSQLServerDatabaseBackup wasn't as clean as I would like. It does work though, and should be unobtrusive. It failed a lot during development, so there is still a lot of failback code to deal with corner cases I may have missed, test environments, etc. In these cases you'll get a clearly bogus date ("1111-11-11").

Ready for testing.