### PR TITLE
PF-2447: moved magic strings for url, username, and password to the web config

### DIFF
--- a/Source/ProjectFirma.Web/Common/FirmaWebConfiguration.cs
+++ b/Source/ProjectFirma.Web/Common/FirmaWebConfiguration.cs
@@ -82,6 +82,10 @@ namespace ProjectFirma.Web.Common
         public static string GeoServerUrl = SitkaConfiguration.GetRequiredAppSetting("GeoServerUrl");
         public static bool TenantDropdownEnabled = Boolean.Parse(SitkaConfiguration.GetRequiredAppSetting("TenantDropdownEnabled"));
 
+        public static readonly string HttpAuthenticationUrlHost = SitkaConfiguration.GetRequiredAppSetting("HttpAuthenticationUrlHost");
+        public static readonly string HttpAuthenticationUsername = SitkaConfiguration.GetRequiredAppSetting("HttpAuthenticationUsername");
+        public static readonly string HttpAuthenticationPassword = SitkaConfiguration.GetRequiredAppSetting("HttpAuthenticationPassword");
+
         // Feature Flag Settings
         // FeatureMatchMakerEnabled now has shipped, but leaving this in place so we can see readily how to set up the next Feature.
         //public static readonly bool FeatureMatchMakerEnabled = Boolean.Parse(SitkaConfiguration.GetRequiredAppSetting("FeatureMatchMakerEnabled"));

--- a/Source/ProjectFirma.Web/Global.asax.cs
+++ b/Source/ProjectFirma.Web/Global.asax.cs
@@ -210,7 +210,7 @@ namespace ProjectFirma.Web
         private static void RequireHttpAuthenticationAsNeeded(HttpRequest httpRequest, HttpResponse httpResponse)
         {
             // ReSharper disable once StringLiteralTypo
-            if (!httpRequest.Url.Host.StartsWith("ncrp.", StringComparison.InvariantCultureIgnoreCase))
+            if (!httpRequest.Url.Host.StartsWith(FirmaWebConfiguration.HttpAuthenticationUrlHost, StringComparison.InvariantCultureIgnoreCase))
             {
                 return;
             }
@@ -219,7 +219,7 @@ namespace ProjectFirma.Web
             {
                 var cred = System.Text.Encoding.ASCII.GetString(Convert.FromBase64String(auth.Substring(6))).Split(':');
                 var user = new { Name = cred[0], Pass = cred[1] };
-                if (user.Name.Equals("foo", StringComparison.InvariantCultureIgnoreCase) && user.Pass == "bar")
+                if (user.Name.Equals(FirmaWebConfiguration.HttpAuthenticationUsername, StringComparison.InvariantCultureIgnoreCase) && user.Pass == FirmaWebConfiguration.HttpAuthenticationPassword)
                 {
                     return;
                 }

--- a/Source/ProjectFirma.Web/Views/Shared/NavAndHeaderLayout.cshtml
+++ b/Source/ProjectFirma.Web/Views/Shared/NavAndHeaderLayout.cshtml
@@ -128,7 +128,15 @@ Source code is available upon request via <support@sitkatech.com>.
                                  <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="tenantDropdownMenu">
                                      @foreach (var tenant in ViewDataTyped.TenantSimples)
                                      {
-                                         <li><a href="@tenant.GetRelativeCanonicalUrlForTenantEnvironment(FirmaWebConfiguration.FirmaEnvironment.FirmaEnvironmentType, ViewDataTyped.CurrentUrl)"><span style="text-align: center; width: 40px; margin-right: 5px; display: inline-block;"><img style="max-height: 20px; width: auto; max-width: 30px" src="@tenant.GetTenantSquareLogoUrlForEnvironment(FirmaWebConfiguration.FirmaEnvironment.FirmaEnvironmentType)" /></span> @tenant.TenantName</a></li>
+                                         if (tenant.TenantID == Tenant.NCRPProjectTracker.TenantID)
+                                         {
+                                             // don't show the tenant logo when the Http Authentication popup is being used
+                                             <li><a href="@tenant.GetRelativeCanonicalUrlForTenantEnvironment(FirmaWebConfiguration.FirmaEnvironment.FirmaEnvironmentType, ViewDataTyped.CurrentUrl)"><span style="text-align: center; width: 40px; margin-right: 5px; display: inline-block;"></span> @tenant.TenantName</a></li>
+                                         }
+                                         else
+                                         {
+                                             <li><a href="@tenant.GetRelativeCanonicalUrlForTenantEnvironment(FirmaWebConfiguration.FirmaEnvironment.FirmaEnvironmentType, ViewDataTyped.CurrentUrl)"><span style="text-align: center; width: 40px; margin-right: 5px; display: inline-block;"><img style="max-height: 20px; width: auto; max-width: 30px" src="@tenant.GetTenantSquareLogoUrlForEnvironment(FirmaWebConfiguration.FirmaEnvironment.FirmaEnvironmentType)" /></span> @tenant.TenantName</a></li>
+                                         }
                                      }
                                      @if (FirmaWebConfiguration.FirmaEnvironment.FirmaEnvironmentType == FirmaEnvironmentType.Qa)
                                      {

--- a/Source/ProjectFirma.Web/Web.config.template
+++ b/Source/ProjectFirma.Web/Web.config.template
@@ -59,6 +59,9 @@
     <add key="ImpersonationAllowed" value="${impersonation-allowed}" />
     <add key="GeoServerUrl" value="${geoserver-url}" />
     <add key="TenantDropdownEnabled" value="${tenant-dropdown-enabled}" />
+    <add key="HttpAuthenticationUrlHost" value="${http-authentication-url-host}" />
+    <add key="HttpAuthenticationUsername" value="${http-authentication-username}" />
+    <add key="HttpAuthenticationPassword" value="${http-authentication-password}" />
 
     <!-- projectfirma.com reCAPTCHA key, be sure to add domain names to reCAPTCHA admin control panel when adding new tenants with new domains -->
     <!-- reCAPTCHA domains as of 09/23/2019: clackamaspartnership.org, idaho.gov, peakstopeople.org, projectfirma.com, pugetsoundinfo.wa.gov, rcdprojects.org -->


### PR DESCRIPTION
Don't show the NCRP logo in the tenant switcher.