### PR TITLE
PF-2438: Conditionally Hide Funding Sources on Organization Detail page

### DIFF
--- a/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
@@ -264,7 +264,7 @@
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="organizationOverview">
                 <div class="row">
-                    <div class="col-md-6">
+                    <div class="@(ViewDataTyped.ShowFundingSources ? "col-md-6" : "col-md-12")">
                         <div class="panel panelFirma">
                             <div class="panel-heading panelTitle">
                                 @ModalDialogFormHelper.MakeEditIconLink(ViewDataTyped.EditOrganizationUrl, string.Format("Edit {0} - {1}", FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel(), ViewDataTyped.Organization.GetDisplayName()), ViewDataTyped.UserHasOrganizationManagePermissions)
@@ -302,19 +302,19 @@
                                             <div class="col-xs-6">@(ViewDataTyped.Organization.OrganizationType != null ? ViewDataTyped.Organization.OrganizationType.OrganizationTypeName : string.Empty)</div>
                                         </div>
                                         <div class="row">
-                                           <div class="col-xs-6 fieldLabel text-right">@Html.LabelWithSugarFor(FieldDefinitionEnum.OrganizationPrimaryContact.ToType())</div>
-                                           <div class="col-xs-6">
-                                              @if (ViewDataTyped.UserHasOrganizationManagePrimaryContactPermissions)
-                                              {
-                                                 <span style="margin-right: 5px">@ModalDialogFormHelper.MakeEditIconLink(ViewDataTyped.EditOrganizationPrimaryContactUrl, string.Format("Edit {0} for {1}", FieldDefinitionEnum.OrganizationPrimaryContact.ToType().FieldDefinitionDisplayName, ViewDataTyped.Organization.OrganizationName), 800, ViewDataTyped.UserHasOrganizationManagePrimaryContactPermissions, null)</span>
-                                              }
-                                              @ViewDataTyped.Organization.GetPrimaryContactPersonWithOrgAsUrl(ViewDataTyped.CurrentFirmaSession)
-                                           </div>
+                                            <div class="col-xs-6 fieldLabel text-right">@Html.LabelWithSugarFor(FieldDefinitionEnum.OrganizationPrimaryContact.ToType())</div>
+                                            <div class="col-xs-6">
+                                                @if (ViewDataTyped.UserHasOrganizationManagePrimaryContactPermissions)
+                                                {
+                                                    <span style="margin-right: 5px">@ModalDialogFormHelper.MakeEditIconLink(ViewDataTyped.EditOrganizationPrimaryContactUrl, string.Format("Edit {0} for {1}", FieldDefinitionEnum.OrganizationPrimaryContact.ToType().FieldDefinitionDisplayName, ViewDataTyped.Organization.OrganizationName), 800, ViewDataTyped.UserHasOrganizationManagePrimaryContactPermissions, null)</span>
+                                                }
+                                                @ViewDataTyped.Organization.GetPrimaryContactPersonWithOrgAsUrl(ViewDataTyped.CurrentFirmaSession)
+                                            </div>
                                         </div>
-                                        
+
                                         <div class="row">
-                                           <div class="col-xs-6 fieldLabel text-right">@Html.LabelWithSugarFor(FieldDefinitionEnum.OrganizationKeystoneGuid.ToType())</div>
-                                           <div class="col-xs-6">@(ViewDataTyped.OrganizationKeystoneGuidDisplayString)</div>
+                                            <div class="col-xs-6 fieldLabel text-right">@Html.LabelWithSugarFor(FieldDefinitionEnum.OrganizationKeystoneGuid.ToType())</div>
+                                            <div class="col-xs-6">@(ViewDataTyped.OrganizationKeystoneGuidDisplayString)</div>
                                         </div>
 
                                     </div>
@@ -322,35 +322,38 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-md-6">
-                        <div class="panel panelFirma">
-                            <div class="panel-heading panelTitle">
-                                @Html.LabelWithSugarFor(FieldDefinitionEnum.FundingSource.ToType(), LabelWithSugarForExtensions.DisplayStyle.HelpIconOnly)
-                                <a href="@ViewDataTyped.ManageFundingSourcesUrl">@FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized()</a>
+                    @if (ViewDataTyped.ShowFundingSources)
+                    {
+                        <div class="col-md-6">
+                            <div class="panel panelFirma">
+                                <div class="panel-heading panelTitle">
+                                    @Html.LabelWithSugarFor(FieldDefinitionEnum.FundingSource.ToType(), LabelWithSugarForExtensions.DisplayStyle.HelpIconOnly)
+                                    <a href="@ViewDataTyped.ManageFundingSourcesUrl">@FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized()</a>
 
-                                <span class="pull-right">
-                                    @ModalDialogFormHelper.ModalDialogFormLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-plus").ToString(), ViewDataTyped.NewFundingSourceUrl, string.Format("Create a new {0}", FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()), new List<string>(), ViewDataTyped.CanCreateNewFundingSource)
-                                </span>
-                            </div>
-                            <div class="panel-body">
-                                @if (ViewDataTyped.Organization.FundingSources.Any())
-                                {
-                                    <ul>
-                                        @foreach (var fundingSource in ViewDataTyped.Organization.FundingSources.OrderBy(x => x.FundingSourceName))
-                                        {
-                                            <li>
-                                                @fundingSource.GetDisplayNameAsUrl()
-                                            </li>
-                                        }
-                                    </ul>
-                                }
-                                else
-                                {
-                                    <p class="systemText">No @FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized() set for this @(FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()).</p>
-                                }
+                                    <span class="pull-right">
+                                        @ModalDialogFormHelper.ModalDialogFormLink(BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-plus").ToString(), ViewDataTyped.NewFundingSourceUrl, string.Format("Create a new {0}", FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabel()), new List<string>(), ViewDataTyped.CanCreateNewFundingSource)
+                                    </span>
+                                </div>
+                                <div class="panel-body">
+                                    @if (ViewDataTyped.Organization.FundingSources.Any())
+                                    {
+                                        <ul>
+                                            @foreach (var fundingSource in ViewDataTyped.Organization.FundingSources.OrderBy(x => x.FundingSourceName))
+                                            {
+                                                <li>
+                                                    @fundingSource.GetDisplayNameAsUrl()
+                                                </li>
+                                            }
+                                        </ul>
+                                    }
+                                    else
+                                    {
+                                        <p class="systemText">No @FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized() set for this @(FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()).</p>
+                                    }
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    }
                 </div>
                 <div class="row">
                     <div class="col-md-12">
@@ -596,7 +599,10 @@
                     <div class="col-xs-12">
                         <p>@FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabel() @FieldDefinitionEnum.ReportedExpenditure.ToType().GetFieldDefinitionLabelPluralized() associated with this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel() are presented in several ways:</p>
                         <ul>
-                            <li>The <strong>Expenditures Provided Directly by this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()</strong> chart shows all @FieldDefinitionEnum.ReportedExpenditure.ToType().GetFieldDefinitionLabelPluralized() that originate with @FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized() owned by this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()</li>
+                            @if (ViewDataTyped.ShowFundingSources)
+                            {
+                                <li>The <strong>Expenditures Provided Directly by this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()</strong> chart shows all @FieldDefinitionEnum.ReportedExpenditure.ToType().GetFieldDefinitionLabelPluralized() that originate with @FieldDefinitionEnum.FundingSource.ToType().GetFieldDefinitionLabelPluralized() owned by this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()</li>
+                            }
                             <li>
                                 The <strong>Expenditures Received from other @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabelPluralized()</strong> chart shows @FieldDefinitionEnum.ReportedExpenditure.ToType().GetFieldDefinitionLabelPluralized() received from other
                                 @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabelPluralized() for all @FieldDefinitionEnum.Project.ToType().GetFieldDefinitionLabelPluralized() where this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel() is the
@@ -607,26 +613,30 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-6">
-                        <div class="panel panelFirma">
-                            <div class="panel-heading panelTitle">
-                                Provided Directly by this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()
-                            </div>
-                            <div class="panel-body">
-                                <div>
-                                    @if (ViewDataTyped.ExpendituresDirectlyFromOrganizationViewGoogleChartViewData.HasData)
-                                    {
-                                        ViewGoogleChart.RenderPartialView(Html, ViewDataTyped.ExpendituresDirectlyFromOrganizationViewGoogleChartViewData);
-                                    }
-                                    else
-                                    {
-                                        <p class="systemText">No expenditure data available</p>
-                                    }
+                    @if (ViewDataTyped.ShowFundingSources)
+                    {
+                        <div class="col-md-6">
+                            <div class="panel panelFirma">
+                                <div class="panel-heading panelTitle">
+                                    Provided Directly by this @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabel()
+                                </div>
+                                <div class="panel-body">
+                                    <div>
+                                        @if (ViewDataTyped.ExpendituresDirectlyFromOrganizationViewGoogleChartViewData.HasData)
+                                        {
+                                            ViewGoogleChart.RenderPartialView(Html, ViewDataTyped.ExpendituresDirectlyFromOrganizationViewGoogleChartViewData);
+                                        }
+                                        else
+                                        {
+                                            <p class="systemText">No expenditure data available</p>
+                                        }
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-md-6">
+                    }
+
+                    <div class="@(ViewDataTyped.ShowFundingSources ? "col-md-6" : "col-md-12")">
                         <div class="panel panelFirma">
                             <div class="panel-heading panelTitle">
                                 Received from Other @FieldDefinitionEnum.Organization.ToType().GetFieldDefinitionLabelPluralized()

--- a/Source/ProjectFirma.Web/Views/Organization/OrganizationDetailViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/OrganizationDetailViewData.cs
@@ -134,6 +134,7 @@ namespace ProjectFirma.Web.Views.Organization
 
         public bool ShouldShowBackgroundTab { get; }
         public string MatchmakerProjectFinderButtonContent { get; }
+        public bool ShowFundingSources { get; }
 
         public OrganizationDetailViewData(FirmaSession currentFirmaSession,
             ProjectFirmaModels.Models.Organization organization,
@@ -296,7 +297,8 @@ namespace ProjectFirma.Web.Views.Organization
             MatchmakerProjectFinderButtonDisabled = !organization.MatchmakerOptIn.HasValue || !organization.MatchmakerOptIn.Value || MatchmakerProfileIncomplete;
             ShouldShowBackgroundTab = DescriptionViewData.HasPageContent || new OrganizationBackgroundEditFeature().HasPermission(currentFirmaSession, organization).HasPermission;
             MatchmakerProjectFinderButtonContent = GetMatchmakerProjectFinderButtonContent(organization, MatchmakerProfileCompletionDictionary);
-            
+
+            ShowFundingSources = Organization.FundingSources.Any() || new FirmaAdminFeature().HasPermissionByFirmaSession(currentFirmaSession);
         }
 
         private string GetMatchmakerProjectFinderButtonContent(ProjectFirmaModels.Models.Organization organization, Dictionary<MatchmakerSubScoreTypeEnum, bool> matchmakerProfileCompletionDictionary)


### PR DESCRIPTION
If an organization has no funding sources, hide the related funding source panels from Overview and Expenditures tabs