### PR TITLE
PF-2486: rework

### DIFF
--- a/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Organization/Detail.cshtml
@@ -317,6 +317,10 @@
                                             <div class="@(ViewDataTyped.ShowFundingSources ? "col-xs-6" : "col-xs-9")">@(ViewDataTyped.OrganizationKeystoneGuidDisplayString)</div>
                                         </div>
 
+                                        <div class="row">
+                                            <div class="@(ViewDataTyped.ShowFundingSources ? "col-xs-6" : "col-xs-3") fieldLabel text-right">@Html.Label("Is Active?")</div>
+                                            <div class="@(ViewDataTyped.ShowFundingSources ? "col-xs-6" : "col-xs-9")">@ViewDataTyped.Organization.IsActive.ToYesNo()</div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/Source/ProjectFirma.Web/Views/Organization/OrganizationIndexGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Organization/OrganizationIndexGridSpec.cs
@@ -43,7 +43,7 @@ namespace ProjectFirma.Web.Views.Organization
             var projectFundingSourceBudgetsDictionary = HttpRequestStorage.DatabaseEntities.ProjectFundingSourceBudgets
                 .GroupBy(x => x.FundingSourceID)
                 .ToDictionary(x => x.Key, y => y.ToList());
-            var peopleDictionary = HttpRequestStorage.DatabaseEntities.People
+            var peopleDictionary = HttpRequestStorage.DatabaseEntities.People.Where(x => x.IsActive)
                 .GroupBy(x => x.OrganizationID)
                 .ToDictionary(x => x.Key, y => y.ToList());
 


### PR DESCRIPTION
Add "Is Active?" field to Org Detail Basics. Update logic of "# of User" column of index grid to only count active users. Updated logic of delete to prevent deleting an org when it is related to non-approved project update batches. Added sentence to confirm delete dialog explaining the relationship to the projects/project updates/funding sources must be removed before the org can be deleted.