### PR TITLE
PF-2556: fix bugs with project update attachments

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/ProjectAttachmentUpdateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectAttachmentUpdateController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Web.Mvc;
 using LtInfo.Common.DesignByContract;
 using LtInfo.Common.MvcResults;
@@ -107,7 +108,17 @@ namespace ProjectFirma.Web.Controllers
                 return ViewDelete(projectAttachmentUpdate, viewModel);
             }
             projectAttachmentUpdate.ProjectUpdateBatch.TickleLastUpdateDate(CurrentFirmaSession);
-            projectAttachmentUpdate.Attachment.DeleteFull(HttpRequestStorage.DatabaseEntities);
+            // if the under lying File Resource is still referenced by the Project, only delete the ProjectUpdateAttachment row but not the File Resource Attachment
+            if (projectAttachmentUpdate.Attachment.ProjectAttachmentsWhereYouAreTheAttachment.Any())
+            {
+                projectAttachmentUpdate.Delete(HttpRequestStorage.DatabaseEntities);
+            }
+            else
+            {
+                // delete ProjectUpdateAttachment row and the File Resource Attachment
+                projectAttachmentUpdate.Attachment.DeleteFull(HttpRequestStorage.DatabaseEntities);
+            }
+            
             return new ModalDialogFormJsonResult();
         }
     }


### PR DESCRIPTION
create a copy of the file resource when starting an update; do not delete file resource on the Project when deleting an attachment on the Update; actually update the additional fields when approving an update. This pattern is now similar to how Project Images are treated.