### PR TITLE
PF-2826: use DefaultTenantCanonicalHostName instead of app setting "a…

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/AccountController.cs
+++ b/Source/ProjectFirma.Web/Controllers/AccountController.cs
@@ -75,7 +75,7 @@ namespace ProjectFirma.Web.Controllers
 
             var returnFromSitkaUrl = SitkaRoute<AccountController>.BuildAbsoluteUrlHttpsFromExpression(c => c.LogOn(""));
 
-            var initiateFromTenantDomainUrl = ConfigurationManager.AppSettings["auth0:initiateFromTenantDomainUrl"];
+            var initiateFromTenantDomainUrl = "https://" + FirmaWebConfiguration.DefaultTenantCanonicalHostName;
             
             var sitka = initiateFromTenantDomainUrl + "/Account/LogOn"
                                                     + "?returnTo=" + HttpUtility.UrlEncode(returnFromSitkaUrl);


### PR DESCRIPTION
…uth0:initiateFromTenantDomainUrl" because we do not have "auth0-initiateFromTenantDomainUrl" in the local.build file do this is never set