### PR TITLE
Fix TCS Project Tracker sync against migrated LtInfo API

### DIFF
--- a/Source/ProjectFirma.Web/ScheduledJobs/SyncProjectImagesForTscProjectTrackerBackgroundJob.cs
+++ b/Source/ProjectFirma.Web/ScheduledJobs/SyncProjectImagesForTscProjectTrackerBackgroundJob.cs
@@ -69,7 +69,9 @@ namespace ProjectFirma.Web.ScheduledJobs
 
                 var recentlyModifiedExternalIDs = new List<int>();
 
-                var getRecentlyModifiedProjectsUrl = $"{apiUrl}/projects/recently-modified?apiKey={FirmaWebConfiguration.LTInfoApiKey}&{queryParameter}";
+                // apiUrl is the LtInfo API origin only (e.g. https://host), no path. Projects live
+                // under /api/projects; file resources live at root under /file-resources.
+                var getRecentlyModifiedProjectsUrl = $"{apiUrl}/api/projects/recently-modified?apiKey={FirmaWebConfiguration.LTInfoApiKey}&{queryParameter}";
                 var response = await client.GetAsync(getRecentlyModifiedProjectsUrl);
                 if (!response.IsSuccessStatusCode)
                 {
@@ -91,7 +93,7 @@ namespace ProjectFirma.Web.ScheduledJobs
                     var project = projects.Single(x => x.ExternalID == externalID);
                     Logger.Info($"Starting Project Images sync for ProjectID: {project?.ProjectID}; ExternalID: {externalID}");
 
-                    var getProjectImagesUrl = $"{apiUrl}/projects/{externalID}/project-images?apiKey={FirmaWebConfiguration.LTInfoApiKey}";
+                    var getProjectImagesUrl = $"{apiUrl}/api/projects/{externalID}/project-images?apiKey={FirmaWebConfiguration.LTInfoApiKey}";
                     var getProjectImages = await client.GetAsync(getProjectImagesUrl);
                     if (!getProjectImages.IsSuccessStatusCode)
                     {
@@ -143,7 +145,11 @@ namespace ProjectFirma.Web.ScheduledJobs
                     Logger.Warn($"\tProjectID: {project.ProjectID}; ExternalID: {projectImageSimpleDto.ProjectID}. No Project Image Timing found for '{projectImageSimpleDto.ProjectImageTiming.ProjectImageTimingName}'");
                     continue;
                 }
-                var createPerson = databaseEntities.AllPeople.SingleOrDefault(x => x.TenantID == tenantID && x.PersonGuid == projectImageSimpleDto.FileResourceInfo.CreatePersonGUID) ??
+                // Match on email: both systems moved off the shared Keystone PersonGuid to Auth0.
+                // Falls back to the first Admin / ESA Admin when the author can't be matched.
+                var createPerson = (!string.IsNullOrWhiteSpace(projectImageSimpleDto.FileResourceInfo.CreatePersonEmail)
+                                       ? databaseEntities.AllPeople.FirstOrDefault(x => x.TenantID == tenantID && x.Email == projectImageSimpleDto.FileResourceInfo.CreatePersonEmail)
+                                       : null) ??
                                     databaseEntities.AllPeople.Where(x => x.TenantID == tenantID && x.RoleID == Role.Admin.RoleID || x.RoleID == Role.ESAAdmin.RoleID).OrderBy(x => x.RoleID).ThenBy(x => x.PersonID).FirstOrDefault();
                 if (createPerson == null)
                 {
@@ -152,7 +158,8 @@ namespace ProjectFirma.Web.ScheduledJobs
                 }
 
                 // get file resource from lt info api
-                var getFileResource = $"{apiUrl}/FileResource/GetWithApiKey/{projectImageSimpleDto.FileResourceInfo.FileResourceInfoGUID}?apiKey={FirmaWebConfiguration.LTInfoApiKey}";
+                // File resources are served at the API root under /file-resources (NOT under /api).
+                var getFileResource = $"{apiUrl}/file-resources/GetWithApiKey/{projectImageSimpleDto.FileResourceInfo.FileResourceInfoGUID}?apiKey={FirmaWebConfiguration.LTInfoApiKey}";
 
                 var response = await client.GetAsync(getFileResource);
                 if (!response.IsSuccessStatusCode)

--- a/Source/ProjectFirma.Web/ScheduledJobs/SyncProjectsForTscProjectTrackerBackgroundJob.cs
+++ b/Source/ProjectFirma.Web/ScheduledJobs/SyncProjectsForTscProjectTrackerBackgroundJob.cs
@@ -119,7 +119,10 @@ namespace ProjectFirma.Web.ScheduledJobs
 
                 var recentlyModifiedExternalIDs = new List<int>();
 
-                var getAllProjectsUrl = $"{apiUrl}/projects/all-projects?apiKey={FirmaWebConfiguration.LTInfoApiKey}&{queryParameter}";
+                // apiUrl is the LtInfo API origin only (e.g. https://host), no path. The Projects
+                // API lives under /api/projects (see LtInfo swagger); file resources live at root
+                // under /file-resources, so the sub-paths are carried here rather than in apiUrl.
+                var getAllProjectsUrl = $"{apiUrl}/api/projects/all-projects?apiKey={FirmaWebConfiguration.LTInfoApiKey}&{queryParameter}";
                 var response = await client.GetAsync(getAllProjectsUrl);
                 if (!response.IsSuccessStatusCode)
                 {
@@ -161,7 +164,7 @@ namespace ProjectFirma.Web.ScheduledJobs
                 }
                 foreach (var project in projectsMissingPrimaryContact)
                 {
-                    var getProjectUrl = $"{apiUrl}/projects/{project.ExternalID}/?apiKey={FirmaWebConfiguration.LTInfoApiKey}";
+                    var getProjectUrl = $"{apiUrl}/api/projects/{project.ExternalID}?apiKey={FirmaWebConfiguration.LTInfoApiKey}";
                     var projectResponse = await client.GetAsync(getProjectUrl);
                     if (!projectResponse.IsSuccessStatusCode)
                     {
@@ -228,7 +231,11 @@ namespace ProjectFirma.Web.ScheduledJobs
             project.SubmissionDate = projectSimpleDto.SubmissionDate;
             project.ApprovalDate = projectSimpleDto.ApprovalDate;
 
-            var primaryContactPerson = databaseEntities.AllPeople.SingleOrDefault(x => x.TenantID == tenantID && x.PersonGuid == projectSimpleDto.PrimaryContactPersonGuid);
+            // Match on email: both systems moved off the shared Keystone PersonGuid to Auth0, so
+            // the GUID is no longer a usable cross-system key.
+            var primaryContactPerson = !string.IsNullOrWhiteSpace(projectSimpleDto.PrimaryContactPersonEmail)
+                ? databaseEntities.AllPeople.FirstOrDefault(x => x.TenantID == tenantID && x.Email == projectSimpleDto.PrimaryContactPersonEmail)
+                : null;
             if (primaryContactPerson != null)
             {
                 project.PrimaryContactPersonID = primaryContactPerson.PersonID;
@@ -735,7 +742,10 @@ namespace ProjectFirma.Web.ScheduledJobs
                     UpdateDate = projectNoteSimpleDto.UpdateDate
                 };
 
-                var createPerson = databaseEntities.AllPeople.SingleOrDefault(x => x.TenantID == tenantID && x.PersonGuid == projectNoteSimpleDto.CreatePersonGuid);
+                // Match on email: both systems moved off the shared Keystone PersonGuid to Auth0.
+                var createPerson = !string.IsNullOrWhiteSpace(projectNoteSimpleDto.CreatePersonEmail)
+                    ? databaseEntities.AllPeople.FirstOrDefault(x => x.TenantID == tenantID && x.Email == projectNoteSimpleDto.CreatePersonEmail)
+                    : null;
                 if (createPerson != null)
                 {
                     projectNote.CreatePersonID = createPerson.PersonID;
@@ -744,7 +754,9 @@ namespace ProjectFirma.Web.ScheduledJobs
                 {
                     projectNote.CreatePersonFullName = projectNoteSimpleDto.CreatePersonFullName;
                 }
-                var updatePerson = databaseEntities.AllPeople.SingleOrDefault(x => x.TenantID == tenantID && x.PersonGuid == projectNoteSimpleDto.UpdatePersonGuid);
+                var updatePerson = !string.IsNullOrWhiteSpace(projectNoteSimpleDto.UpdatePersonEmail)
+                    ? databaseEntities.AllPeople.FirstOrDefault(x => x.TenantID == tenantID && x.Email == projectNoteSimpleDto.UpdatePersonEmail)
+                    : null;
                 if (updatePerson != null)
                 {
                     projectNote.UpdatePersonID = updatePerson.PersonID;

--- a/Source/ProjectFirmaModels/Models/DataTransferObjects/FileResourceInfoSimpleDto.cs
+++ b/Source/ProjectFirmaModels/Models/DataTransferObjects/FileResourceInfoSimpleDto.cs
@@ -12,6 +12,9 @@ namespace ProjectFirmaModels.Models.DataTransferObjects
         public Guid FileResourceInfoGUID { get; set; }
         public int CreatePersonID { get; set; }
         public Guid CreatePersonGUID { get; set; }
+        // Email is the join key for matching the create person to local People (both systems
+        // moved off the shared Keystone GUID to Auth0).
+        public string CreatePersonEmail { get; set; }
         public DateTime CreateDate { get; set; }
         public FileResourceDatumSimpleDto FileResourceDatum { get; set; }
         public FileResourceMimeTypeSimpleDto FileResourceMimeType { get; set; }

--- a/Source/ProjectFirmaModels/Models/DataTransferObjects/ProjectNoteDto.cs
+++ b/Source/ProjectFirmaModels/Models/DataTransferObjects/ProjectNoteDto.cs
@@ -16,6 +16,10 @@ namespace ProjectFirmaModels.Models.DataTransferObjects
         public string UpdatePersonFullName { get; set; }
         public Guid? CreatePersonGuid{ get; set; }
         public Guid? UpdatePersonGuid { get; set; }
+        // Email is the join key for matching note authors to local People (both systems moved
+        // off the shared Keystone GUID to Auth0).
+        public string CreatePersonEmail { get; set; }
+        public string UpdatePersonEmail { get; set; }
     }
 
 }


### PR DESCRIPTION
The LtInfo Projects API was migrated to .NET and its shape/routes changed. Update the TCS Project Tracker sync jobs accordingly:

- Match people by email instead of the retired Keystone PersonGuid (both systems are on Auth0 now, and the shared GUID is gone). Primary contact, note authors, and image create-person all key on email; add CreatePersonEmail / UpdatePersonEmail to ProjectNoteDto and CreatePersonEmail to FileResourceInfoSimpleDto.
- Fix API routes: projects moved to /api/projects/... and file resources to /file-resources/GetWithApiKey/... (were /projects/... and /FileResource/...). ProjectExternalDataSourceApiUrl should now be the API origin only (no path); the sub-paths are carried in code.

Paired with the ProjectConsumerDto graph restoration in the ltinfo repo.