### PR TITLE
TCS Project Tracker sync: email-only person matching, Hangfire Auth0 fix

### DIFF
--- a/Source/ProjectFirma.Web/ScheduledJobs/HangfireFirmaWebAuthorizationFilter.cs
+++ b/Source/ProjectFirma.Web/ScheduledJobs/HangfireFirmaWebAuthorizationFilter.cs
@@ -1,8 +1,7 @@
 ﻿using Hangfire.Dashboard;
-using Keystone.Common.OpenID;
 using Microsoft.Owin;
 using ProjectFirma.Web.Common;
-using ProjectFirma.Web.Models;
+using ProjectFirma.Web.Controllers;
 
 namespace ProjectFirma.Web.ScheduledJobs
 {
@@ -10,11 +9,15 @@ namespace ProjectFirma.Web.ScheduledJobs
     {
         public bool Authorize(DashboardContext context)
         {
+            // The Hangfire dashboard runs as OWIN middleware outside the MVC pipeline, so
+            // HttpRequestStorage.FirmaSession is never populated here (it stays the anonymous
+            // session, Person == null). Resolve the session straight from the authenticated OWIN
+            // principal the same way the MVC pipeline does (ClaimsIdentityHelper), which branches
+            // per auth mode (Auth0 / Keystone / Local). The old code used the Keystone-only helper
+            // directly, so admins were 403'd under Auth0. Admin is still required.
             var owinContext = new OwinContext(context.GetOwinEnvironment());
-            var person = KeystoneClaimsHelpers.GetOpenIDUserFromPrincipal(owinContext.Authentication.User,
-                null,
-                HttpRequestStorage.DatabaseEntities.People.GetPersonByPersonGuid);
-            return person.IsAdministrator();
+            var firmaSession = ClaimsIdentityHelper.FirmaSessionFromClaimsIdentity(owinContext.Authentication, HttpRequestStorage.Tenant);
+            return firmaSession?.IsAdministrator() ?? false;
         }
     }
 }

--- a/Source/ProjectFirma.Web/ScheduledJobs/SyncProjectImagesForTscProjectTrackerBackgroundJob.cs
+++ b/Source/ProjectFirma.Web/ScheduledJobs/SyncProjectImagesForTscProjectTrackerBackgroundJob.cs
@@ -150,10 +150,10 @@ namespace ProjectFirma.Web.ScheduledJobs
                 var createPerson = (!string.IsNullOrWhiteSpace(projectImageSimpleDto.FileResourceInfo.CreatePersonEmail)
                                        ? databaseEntities.AllPeople.FirstOrDefault(x => x.TenantID == tenantID && x.Email == projectImageSimpleDto.FileResourceInfo.CreatePersonEmail)
                                        : null) ??
-                                    databaseEntities.AllPeople.Where(x => x.TenantID == tenantID && x.RoleID == Role.Admin.RoleID || x.RoleID == Role.ESAAdmin.RoleID).OrderBy(x => x.RoleID).ThenBy(x => x.PersonID).FirstOrDefault();
+                                    databaseEntities.AllPeople.Where(x => x.TenantID == tenantID && (x.RoleID == Role.Admin.RoleID || x.RoleID == Role.ESAAdmin.RoleID)).OrderBy(x => x.RoleID).ThenBy(x => x.PersonID).FirstOrDefault();
                 if (createPerson == null)
                 {
-                    Logger.Warn($"\tProjectID: {project.ProjectID}; ExternalID: {projectImageSimpleDto.ProjectID}. No Create Person found for '{projectImageSimpleDto.FileResourceInfo.CreatePersonGUID}' and the system could not default the Create Person to a current Admin or ESA Admin");
+                    Logger.Warn($"\tProjectID: {project.ProjectID}; ExternalID: {projectImageSimpleDto.ProjectID}. No Create Person found for email '{projectImageSimpleDto.FileResourceInfo.CreatePersonEmail}' and the system could not default the Create Person to a current Admin or ESA Admin");
                     continue;
                 }
 

--- a/Source/ProjectFirmaModels/Models/DataTransferObjects/FileResourceInfoSimpleDto.cs
+++ b/Source/ProjectFirmaModels/Models/DataTransferObjects/FileResourceInfoSimpleDto.cs
@@ -11,9 +11,8 @@ namespace ProjectFirmaModels.Models.DataTransferObjects
         public string OriginalFileExtension { get; set; }
         public Guid FileResourceInfoGUID { get; set; }
         public int CreatePersonID { get; set; }
-        public Guid CreatePersonGUID { get; set; }
-        // Email is the join key for matching the create person to local People (both systems
-        // moved off the shared Keystone GUID to Auth0).
+        // Email is the join key for matching the create person to local People. There is no
+        // cross-system person GUID (each system's Auth0 sub is tenant-specific).
         public string CreatePersonEmail { get; set; }
         public DateTime CreateDate { get; set; }
         public FileResourceDatumSimpleDto FileResourceDatum { get; set; }

--- a/Source/ProjectFirmaModels/Models/DataTransferObjects/ProjectNoteDto.cs
+++ b/Source/ProjectFirmaModels/Models/DataTransferObjects/ProjectNoteDto.cs
@@ -14,10 +14,8 @@ namespace ProjectFirmaModels.Models.DataTransferObjects
         public DateTime? UpdateDate { get; set; }
         public string CreatePersonFullName { get; set; }
         public string UpdatePersonFullName { get; set; }
-        public Guid? CreatePersonGuid{ get; set; }
-        public Guid? UpdatePersonGuid { get; set; }
-        // Email is the join key for matching note authors to local People (both systems moved
-        // off the shared Keystone GUID to Auth0).
+        // Email is the join key for matching note authors to local People. There is no cross-system
+        // person GUID (each system's Auth0 sub is tenant-specific, so it can't be used to join).
         public string CreatePersonEmail { get; set; }
         public string UpdatePersonEmail { get; set; }
     }

--- a/Source/ProjectFirmaModels/Models/DataTransferObjects/ProjectSimpleDto.cs
+++ b/Source/ProjectFirmaModels/Models/DataTransferObjects/ProjectSimpleDto.cs
@@ -37,7 +37,6 @@ namespace ProjectFirmaModels.Models.DataTransferObjects
         public string ProjectLocationAreaType { get; set; }
         public string PrimaryContactPersonFullName { get; set; }
         public string PrimaryContactPersonEmail { get; set; }
-        public Guid? PrimaryContactPersonGuid { get; set; }
         public ProjectApprovalStatusSimpleDto ProjectApprovalStatus { get; set; }
         public List<ProjectImplementingOrganizationOrProjectFundingOrganizationSimpleDto> Organizations { get; set; }
         public string ProjectLocationPointGeoJson { get; set; }


### PR DESCRIPTION
Follow-up from end-to-end testing of the TCS Project Tracker sync:

- Drop the person GUID fields from the sync DTOs (PrimaryContactPersonGuid, note Create/UpdatePersonGuid, FileResourceInfo.CreatePersonGUID). Each system's Auth0 sub is tenant-specific, so there is no cross-system person GUID; matching is by email. This also resolves a null -> non-nullable Guid deserialization error.
- Fix the Hangfire dashboard authorization filter: it resolved the user via the Keystone-only claims helper, which 403'd Auth0-authenticated admins. Resolve the session from the OWIN principal via ClaimsIdentityHelper (auth-mode agnostic); admin is still required.
- Fix an operator-precedence bug in the image create-person admin fallback so the Admin/ESA-Admin match is tenant-scoped (was matching ESA Admins across tenants).
- Point the image create-person warning log at the email (the actual match key).